### PR TITLE
Fix andres build

### DIFF
--- a/tools/ignition_rendering.BUILD
+++ b/tools/ignition_rendering.BUILD
@@ -140,6 +140,8 @@ cc_library(
         "include/ignition/rendering/config.hh",  # from cmake_configure_file above
         "include/ignition/rendering/base/base.hh",  # from cmake_configure_file above
         "include/ignition/rendering/ogre/ogre.hh",  # from cmake_configure_file above
+        "include/ignition/rendering.hh",
+        "include/ignition/rendering/RenderTarget.hh",
         "src/base/BaseObject.cc",
         "src/base/BaseRenderEngine.cc",
         "src/base/BaseScene.cc",


### PR DESCRIPTION
This PR fixes a few issues that @basicNew encountered when using the build system for the visualizer.  Essentially it makes sure that bazel knows about all of the header dependencies, which it didn't know before.