### PR TITLE
Rename everything internal to delphyne.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Drakaina
+# Delphyne
 
-This is the repository for Drakaina.  As of right now, the only supported platform is Ubuntu 16.04 amd64.
+This is the repository for Delphyne.  As of right now, the only supported platform is Ubuntu 16.04 amd64.
 
 # Setup instructions
 
-1.  You first need to install the dependencies for Drake.  While Drakaina doesn't directly depend on Drake right now, it may in the future and the build system aims to be compatible.  The instructions are [here](http://drake.mit.edu/from_source.html), but in brief:
+1.  You first need to install the dependencies for Drake.  While Delphyne doesn't directly depend on Drake right now, it may in the future and the build system aims to be compatible.  The instructions are [here](http://drake.mit.edu/from_source.html), but in brief:
 
     ```
     $ git clone git@github.com:RobotLocomotion/drake.git drake-distro

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "drakaina")
+workspace(name = "delphyne")
 
 load("//tools:github.bzl", "github_archive")
 load("//tools:bitbucket.bzl", "bitbucket_archive")

--- a/tools/README.bazel_shared_library
+++ b/tools/README.bazel_shared_library
@@ -6,7 +6,7 @@ approach to building.  One thing that falls out naturally from this is that
 Bazel really prefers to build everything statically, with no shared objects.
 Unfortunately, if your project must use shared objects, you basically have to
 trick Bazel into doing the correct thing.  This document describes how that
-trick works, since it is used a few different places in drakaina.
+trick works, since it is used a few different places in delphyne.
 
 Overview
 --------

--- a/tools/install.bzl
+++ b/tools/install.bzl
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("@drakaina//tools:pathutils.bzl", "dirname", "output_path", "join_paths")
+load("@delphyne//tools:pathutils.bzl", "dirname", "output_path", "join_paths")
 
 InstallInfo = provider()
 

--- a/tools/lcm.BUILD
+++ b/tools/lcm.BUILD
@@ -1,9 +1,9 @@
 # -*- python -*-
 
-load("@drakaina//tools:drake.bzl", "drake_generate_file")
-load("@drakaina//tools:generate_export_header.bzl", "generate_export_header")
+load("@delphyne//tools:drake.bzl", "drake_generate_file")
+load("@delphyne//tools:generate_export_header.bzl", "generate_export_header")
 load(
-    "@drakaina//tools:install.bzl",
+    "@delphyne//tools:install.bzl",
     "cmake_config",
     "install",
     "install_cmake_config",

--- a/tools/lcm.bzl
+++ b/tools/lcm.bzl
@@ -1,10 +1,10 @@
 # -*- python -*-
 
 load(
-    "@drakaina//tools:generate_include_header.bzl",
+    "@delphyne//tools:generate_include_header.bzl",
     "drake_generate_include_header",
 )
-load("@drakaina//tools:pathutils.bzl", "basename", "dirname", "join_paths")
+load("@delphyne//tools:pathutils.bzl", "basename", "dirname", "join_paths")
 
 def _lcm_aggregate_hdr(
         lcm_package,


### PR DESCRIPTION
Note that after this change, everyone will have to do: `bazel clean --expunge`, and then rebuild from scratch again.  @caguero @basicNew @apojomovsky , review appreciated.