### PR TITLE
Fix multiple plugins build.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,6 +26,11 @@ pkg_config_package(
 )
 
 pkg_config_package(
+    name = "ignition-math3",
+    modname = "ignition-math3",
+)
+
+pkg_config_package(
     name = "ignition-transport3",
     modname = "ignition-transport3",
 )

--- a/tools/ign-gui.bzl
+++ b/tools/ign-gui.bzl
@@ -1,10 +1,22 @@
 # -*- python -*-
 
-def ign_gui_create_plugin(name, srcfile):
+load("@//tools:qt.bzl", "qt_moc_gen")
+load("@//tools:pathutils.bzl", "basename")
+
+def ign_gui_create_plugin(name, srcfile, mochdr):
+    moc_filename = "moc_" + basename(srcfile)
+
+    qt_moc_gen(
+        name = "moc_" + name,
+        hdr = mochdr,
+        out = moc_filename,
+    )
+
     native.cc_library(
         name = "ign-gui-0/plugins/_" + name,
         srcs = [
             srcfile,
+            moc_filename,
             "@ignition_common//:libignition_common.so",
         ],
         includes = ["include"],

--- a/tools/ignition_common.BUILD
+++ b/tools/ignition_common.BUILD
@@ -96,6 +96,13 @@ genrule(
     ) + ") > '$@'",
 )
 
+cc_library(
+    name = "ignition_common_headers_only",
+    includes = ["include"],
+    hdrs = public_headers,
+    visibility = ["//visibility:public"],
+)
+
 # Generates the library exported to users.  The explicitly listed srcs= matches
 # upstream's explicitly listed sources plus private headers.  The explicitly
 # listed hdrs= matches upstream's public headers.
@@ -150,11 +157,10 @@ cc_library(
         "src/VideoEncoder.cc",
         "src/WorkerPool.cc",
     ],
-    hdrs = public_headers,
-    includes = ["include"],
     deps = [
         "@avdevice",
         "@glib",
+        ":ignition_common_headers_only",
         "@ignition-transport3",
         "@uuid",
     ],

--- a/tools/ignition_gui.BUILD
+++ b/tools/ignition_gui.BUILD
@@ -85,12 +85,22 @@ qt_rcc_gen(
 # Create all of the plugins here as separate shared objects.  The code
 # to do this lives in ign-gui.bzl, since Bazel does not allow functions
 # inside of BUILD files.
-ign_gui_create_plugin("libImageDisplay.so", "src/plugins/ImageDisplay.cc")
-ign_gui_create_plugin("libPublisher.so", "src/plugins/Publisher.cc")
-ign_gui_create_plugin("libRequester.so", "src/plugins/Requester.cc")
-ign_gui_create_plugin("libResponder.so", "src/plugins/Responder.cc")
-ign_gui_create_plugin("libTimePanel.so", "src/plugins/TimePanel.cc")
-ign_gui_create_plugin("libTopicEcho.so", "src/plugins/TopicEcho.cc")
+ign_gui_create_plugin("libImageDisplay.so", "src/plugins/ImageDisplay.cc", "include/ignition/gui/plugins/ImageDisplay.hh")
+ign_gui_create_plugin("libPublisher.so", "src/plugins/Publisher.cc", "include/ignition/gui/plugins/Publisher.hh")
+ign_gui_create_plugin("libRequester.so", "src/plugins/Requester.cc", "include/ignition/gui/plugins/Requester.hh")
+ign_gui_create_plugin("libResponder.so", "src/plugins/Responder.cc", "include/ignition/gui/plugins/Responder.hh")
+ign_gui_create_plugin("libTimePanel.so", "src/plugins/TimePanel.cc", "include/ignition/gui/plugins/TimePanel.hh")
+ign_gui_create_plugin("libTopicEcho.so", "src/plugins/TopicEcho.cc", "include/ignition/gui/plugins/TopicEcho.hh")
+
+cc_library(
+    name = "ignition_gui_headers_only",
+    includes = ["include"],
+    hdrs = public_headers + [iface_header, mainwindow_header, plugin_header],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@Qt5Core",
+    ],
+)
 
 # Generates the library exported to users.  The explicitly listed srcs= matches
 # upstream's explicitly listed sources plus private headers.  The explicitly
@@ -110,11 +120,10 @@ cc_library(
         "moc_plugin.cc",  # from qt_moc_gen above
         "@ignition_common//:libignition_common.so",
     ],
-    includes = ["include"],
-    hdrs = public_headers + [iface_header, mainwindow_header, plugin_header],
     deps = [
         "@gts",
         "@ignition_common//:ignition_common_shared_library",
+        ":ignition_gui_headers_only",
         "@ignition-transport3",
         "@Qt5Core",
         "@Qt5Gui",

--- a/tools/ignition_rendering.BUILD
+++ b/tools/ignition_rendering.BUILD
@@ -139,6 +139,17 @@ genrule(
     ) + ") > '$@'",
 )
 
+cc_library(
+    name = "ignition_rendering_headers_only",
+    includes = ["include"],
+    hdrs = public_headers + public_base_headers + public_ogre_headers,
+    visibility = ["//visibility:public"],
+    deps = [
+        "@ignition_common//:ignition_common_headers_only",
+        "@ignition-math3",
+    ],
+)
+
 # Generates the library exported to users.  The explicitly listed srcs= matches
 # upstream's explicitly listed sources plus private headers.  The explicitly
 # listed hdrs= matches upstream's public headers.
@@ -179,14 +190,13 @@ cc_library(
         "src/SystemPaths.cc",
         "@ignition_common//:libignition_common.so",
     ],
-    hdrs = public_headers + public_base_headers + public_ogre_headers,
     defines = [
         # FIXME(clalancette): we should not hard-code this
         'IGN_RENDERING_PLUGIN_PATH=\\"ign-rendering-0/plugins\\"',
     ],
-    includes = ["include"],
     deps = [
         "@ignition_common//:ignition_common_shared_library",
+        ":ignition_rendering_headers_only",
         "@OGRE",
         "@OGRE-Paging",
         "@OGRE-RTShaderSystem",

--- a/visualizer/BUILD
+++ b/visualizer/BUILD
@@ -4,14 +4,21 @@ cc_library(
     name = "_libRenderWidget.so",
     srcs = [
         "RenderWidget.cc",
-        "@ignition_common//:libignition_common.so",
-        "@ignition_gui//:libignition_gui.so",
         "@ignition_rendering//:libignition_rendering.so",
     ],
     deps = [
-        "@ignition_common//:ignition_common_shared_library",
-        "@ignition_gui//:ignition_gui_shared_library",
-        "@ignition_rendering//:ignition_rendering_shared_library",
+        # clalancette: it is *critical* that we only depend on the headers
+        # from ignition-gui here.  If we use the shared_library dependency,
+        # then a whole extra copy of the ignition-gui code gets linked into
+        # the plugins.  When that plugin gets loaded, it ends up doing static
+        # initialization of C++ global objects again (which ignition-gui uses),
+        # blowing everything up.  In theory, the same situation applies for
+        # ignition-common and ignition-rendering.  We fix ignition-common the
+        # same way as ignition-gui here (by only depending on the headers), but
+        # ignition-rendering is different for reasons I don't fully understand.
+        "@ignition_common//:ignition_common_headers_only",
+        "@ignition_gui//:ignition_gui_headers_only",
+        "@ignition_rendering//:ignition_rendering_headers_only",
     ],
     linkstatic = 1,
 )

--- a/visualizer/visualizer.cc
+++ b/visualizer/visualizer.cc
@@ -52,6 +52,8 @@ int main(int argc, char *argv[])
   ignition::gui::addPluginPath(IGN_GUI_DEFAULT_PLUGIN_PATH);
 
   ignition::gui::loadPlugin("RenderWidget");
+  ignition::gui::loadPlugin("TimePanel");
+  ignition::gui::loadPlugin("TopicEcho");
 
   // Create main window
   ignition::gui::createMainWindow();


### PR DESCRIPTION
The problem was that we were linking a whole additional
copy of ignition-gui into the RenderWidget plugin, so
that when the plugin got loaded, it called all of the
static initialization again, blowing away global variables.
Switch to only depending on the headers instead.

This should fix the problem I previously mentioned where we could only load a single plugin at a time.  I proved that this is fixed by adding a couple of other plugins to the main visualizer window.  @caguero @basicNew @apojomovsky @stonier , take a look when you get a chance.