### PR TITLE
Switch back to using ignition common console.

### DIFF
--- a/bridge/BUILD
+++ b/bridge/BUILD
@@ -54,6 +54,7 @@ cc_binary(
         "drake/lcmt_viewer_load_robot.hpp",
     ],
     deps = [
+        "@ignition_common//:ignition_common_shared_library",
         "@lcm",
     ],
 )

--- a/bridge/lcm_channel_repeater.hh
+++ b/bridge/lcm_channel_repeater.hh
@@ -100,9 +100,9 @@ class LcmChannelRepeater {
       translate(*lcm_msg, &ign_msg);
       publisher_.Publish(ign_msg);
     } catch(const delphyne::bridge::TranslateException &e) {
-      std::cout << "An error occurred while trying to translate a message in channel " << chan <<
+      ignerr << "An error occurred while trying to translate a message in channel " << chan <<
       ": " << std::endl;
-      std::cout << e.what() << std::endl;
+      ignerr << e.what() << std::endl;
     }
   }
 };

--- a/bridge/lcm_mock_robot_publisher.cc
+++ b/bridge/lcm_mock_robot_publisher.cc
@@ -33,6 +33,8 @@
 #include <thread>
 #include <vector>
 
+#include <ignition/common/Console.hh>
+
 #include <lcm/lcm-cpp.hpp>
 #include "drake/lcmt_viewer_geometry_data.hpp"
 #include "drake/lcmt_viewer_link_data.hpp"
@@ -48,9 +50,12 @@
 // - A mesh loaded from a "package" styled path
 
 int main(int argc, char* argv[]) {
+  ignition::common::Console::SetVerbosity(3);
+  ignmsg << "Starting up mock publisher" << std::endl;
+
   lcm::LCM lcm;
   if (!lcm.good()) {
-    std::cout << "Failed to initialize LCM" << std::endl;
+    ignerr << "Failed to initialize LCM" << std::endl;
     return 1;
   }
   // fixed values used to override the non-initialized variables from the
@@ -199,9 +204,9 @@ int main(int argc, char* argv[]) {
   // Publish a robot message into the lcm_channel every 1 second
   while (1) {
     std::string lcm_channel = "DRAKE_VIEWER_LOAD_ROBOT";
-    std::cout << "Publishing message into " << lcm_channel << std::endl;
+    ignmsg << "Publishing message into " << lcm_channel << std::endl;
     if (lcm.publish(lcm_channel, &robotMsg) == -1) {
-      std::cout << "Failed to publish message into " << lcm_channel
+      ignerr << "Failed to publish message into " << lcm_channel
                 << std::endl;
       return 1;
     }

--- a/bridge/lcm_to_ign_transport_bridge.cc
+++ b/bridge/lcm_to_ign_transport_bridge.cc
@@ -52,10 +52,10 @@ int main(int argc, char* argv[]) {
   try {
     viewerLoadRobotRepeater.Start();
   } catch (const std::runtime_error& error) {
-    std::cout << "Failed to start LCM channel repeater for initialize "
+    ignerr << "Failed to start LCM channel repeater for initialize "
                  "DRAKE_VIEWER_LOAD_ROBOT"
               << std::endl;
-    std::cout << "Details: " << error.what() << std::endl;
+    ignerr << "Details: " << error.what() << std::endl;
     exit(1);
   }
 


### PR DESCRIPTION
Now that we have fixed the problems with ignition common console,
switch back to using it everywhere.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>