### PR TITLE
Since service_to_channel_translation needs LCM directly, add it to th…

### DIFF
--- a/bridge/BUILD
+++ b/bridge/BUILD
@@ -50,6 +50,7 @@ cc_library(
     hdrs = ["service_to_channel_translation.hh"],
     deps = [
         "@ignition-transport3",
+        "@lcm",
         "//bridge:drake-lcmt-headers",
     ],
 )


### PR DESCRIPTION
…e dependencies.

This fixes the build for me.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>