### PR TITLE
Make sure to set the title of the RenderWidget.

### DIFF
--- a/visualizer/RenderWidget.cc
+++ b/visualizer/RenderWidget.cc
@@ -94,6 +94,8 @@ RenderWidget::RenderWidget(QWidget *parent)
   this->setMouseTracking(true);
   this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
+  this->title = "RenderWidget";
+
   // The below block means that every time the updateTime expires, we do an
   // update on the widget. Later on, we call the start() method to start this
   // time at a fixed frequency.  Note that we do not start this timer until the


### PR DESCRIPTION
Otherwise, the lable in the right-click menu of the top-level
window shows up as blank.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>