### PR TITLE
Mysterious sha change for a github archive

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -122,7 +122,7 @@ github_archive(
     name = "lcm",
     repository = "lcm-proj/lcm",
     commit = "c0a0093a950fc83e12e8d5918a0319b590356e7e",
-    sha256 = "d5bb1a0153b9c1526590e7d65be8ca79e4f5e9bf4ce58178c992eaca49d17fb0",
+    sha256 = "f967e74e639ea56318242e93c77a15a504345c8200791cab70d9dad86aa969b2",
     build_file = "tools/lcm.BUILD",
 )
 


### PR DESCRIPTION
Github perhaps changed the way they packed tarballs? Drake had to do this too. See [here](https://github.com/RobotLocomotion/drake/commit/96956aa9341f3d3c2e44d4113bb837bbfa087fc2).