### PR TITLE
Apply transparency to simple shapes

### DIFF
--- a/visualizer/RenderWidget.cc
+++ b/visualizer/RenderWidget.cc
@@ -210,6 +210,10 @@ bool RenderWidget::CreateVisual(const ignition::msgs::Visual &_vis,
     }
   }
 
+  if (_vis.has_transparency()) {
+    _material->SetTransparency(_vis.transparency());
+  }
+
   _material->SetShininess(50);
   _material->SetReflectivity(0);
 


### PR DESCRIPTION
We were ignoring the transparency value when rendering spheres, cylinders and boxes.