### PR TITLE
Add a Ctrl+Q shortcut to quit

### DIFF
--- a/visualizer/visualizer.cc
+++ b/visualizer/visualizer.cc
@@ -89,6 +89,11 @@ int main(int argc, char* argv[]) {
   ignition::gui::createMainWindow();
 
   auto win = ignition::gui::mainWindow();
+
+  // Register a Ctrl + Q keyboard shortcut for quitting the visualizer
+  QShortcut *shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), win);
+  QObject::connect(shortcut, &QShortcut::activated, win, &ignition::gui::stop);
+
   win->setWindowTitle(versionStr);
 
   ignition::gui::runMainWindow();


### PR DESCRIPTION
- Fixes #90 and addresses a part of #91, to which I'm adding some comments now
- Adds a signal/slot connection to handle the `CTRL + Q` key combination for exiting the visualizer
