### PR TITLE
[Do not merge] Save config after closing main window

### DIFF
--- a/visualizer/visualizer.cc
+++ b/visualizer/visualizer.cc
@@ -93,6 +93,10 @@ int main(int argc, char* argv[]) {
 
   ignition::gui::runMainWindow();
 
+  // Save configuration after the window has
+  // been closed (but not destroyed)
+  win->SaveConfig(ignition::gui::defaultConfigPath());
+
   ignition::gui::stop();
 
   return 0;


### PR DESCRIPTION
- Fixes #113 
- Based on [PR #45](https://bitbucket.org/ignitionrobotics/ign-gui/pull-requests/45/example-of-saving-configuration-every-time) from ign-gui
- Saves the current config on the file pointed by the defaultConfigPath just after the main window has been closed.
- Works nicely with the Ctrl+Q shortcut, as well as with the "X" button and the Alt+F4 keys.