### PR TITLE
Make visualizer link against ign-msgs.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -113,6 +113,11 @@ pkg_config_package(
     modname = "ignition-rendering",
 )
 
+pkg_config_package(
+    name = "ignition-msgs0",
+    modname = "ignition-msgs0",
+)
+
 github_archive(
     name = "lcm",
     repository = "lcm-proj/lcm",

--- a/visualizer/BUILD
+++ b/visualizer/BUILD
@@ -79,6 +79,7 @@ cc_binary(
     deps = [
         "@ignition-common0",
         "@ignition-gui",
+        "@ignition-msgs0",
     ],
     linkstatic = 0,
     copts = [


### PR DESCRIPTION
Newer versions of ign-gui require ign-msgs.  It shouldn't hurt
to add it for older versions either, so just unconditionally
do it here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@basicNew @apojomovsky @caguero Additional testing on your setups appreciated, just to make sure that my claim that it "doesn't hurt" is true.