### PR TITLE
Fixes to make demo_launcher.py work.

### DIFF
--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -60,7 +60,7 @@ install(TARGETS lcm-mock-robot-publisher DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
 # ----------------------------------------
 
 install(FILES launcher.py DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python2.7/site-packages/launcher)
-install(PROGRAMS mocked_robot_demo.py DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+install(PROGRAMS mocked_robot_demo.py demo_launcher.py DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 
 # ----------------------------------------
 # Tests


### PR DESCRIPTION
Mostly fixes to paths in `demo_launcher.py` to find executables in the new cmake scheme.  Along with ToyotaResearchInstitute/delphyne-gui#6, makes `demo_launcher` work again.