### PR TITLE
Addresses the error "Is this a non-const reference?" of cpplint

### DIFF
--- a/bridge/ign_service_converter.h
+++ b/bridge/ign_service_converter.h
@@ -95,7 +95,9 @@ class IgnitionServiceConverter {
   /// convertServiceToMsg overloaded function and publish the
   /// result into an lcm channel
   void IgnitionConverterHandler(const IGN_REQ_TYPE& request,
+                                // NOLINTNEXTLINE(runtime/references) due to ign-transport API
                                 ignition::msgs::Boolean& response,
+                                // NOLINTNEXTLINE(runtime/references) due to ign-transport API
                                 bool& result) {
     LCM_TYPE message = delphyne::bridge::convertServiceToMsg(request);
     if (lcm_->publish(lcmChannelName_, &message) != -1) {

--- a/bridge/lcm_channel_repeater_TEST.cc
+++ b/bridge/lcm_channel_repeater_TEST.cc
@@ -23,14 +23,14 @@ void assertIsBoxWithSize(const ignition::msgs::Geometry& message, float x,
 //////////////////////////////////////////////////
 /// \brief Fill an LCM viewer_geometry_data message with a box
 /// geometry with the specified size
-void fillBoxWith(drake::lcmt_viewer_geometry_data& boxMsg, float x, float y,
+void fillBoxWith(drake::lcmt_viewer_geometry_data* boxMsg, float x, float y,
                  float z) {
-  boxMsg.type = boxMsg.BOX;
-  boxMsg.num_float_data = 3;
-  boxMsg.float_data.resize(boxMsg.num_float_data);
-  boxMsg.float_data[0] = x;
-  boxMsg.float_data[1] = y;
-  boxMsg.float_data[2] = z;
+  boxMsg->type = boxMsg->BOX;
+  boxMsg->num_float_data = 3;
+  boxMsg->float_data.resize(boxMsg->num_float_data);
+  boxMsg->float_data[0] = x;
+  boxMsg->float_data[1] = y;
+  boxMsg->float_data[2] = z;
 }
 
 //////////////////////////////////////////////////
@@ -82,7 +82,7 @@ GTEST_TEST(LCMChannelRepeaterTest, TestEndToEndEcho) {
 
   // Create and publish geometry message
   drake::lcmt_viewer_geometry_data boxMsg;
-  fillBoxWith(boxMsg, 1, 2, 3);
+  fillBoxWith(&boxMsg, 1, 2, 3);
 
   lcm->publish("TEST_CHANNEL_1", &boxMsg);
 
@@ -114,7 +114,7 @@ GTEST_TEST(LCMChannelRepeaterTest, TestHandlerNotCalled) {
 
   // Create and publish geometry message
   drake::lcmt_viewer_geometry_data boxMsg;
-  fillBoxWith(boxMsg, 1, 2, 3);
+  fillBoxWith(&boxMsg, 1, 2, 3);
 
   lcm->publish("TEST_CHANNEL_1", &boxMsg);
 
@@ -159,13 +159,13 @@ GTEST_TEST(LCMChannelRepeaterTest, TestMultipleChannels) {
 
   // Create and publish geometry message to channel 1
   drake::lcmt_viewer_geometry_data box1Msg;
-  fillBoxWith(box1Msg, 1, 2, 3);
+  fillBoxWith(&box1Msg, 1, 2, 3);
 
   lcm->publish("TEST_CHANNEL_1", &box1Msg);
 
   // Create and publish geometry message to channel 2
   drake::lcmt_viewer_geometry_data box2Msg;
-  fillBoxWith(box2Msg, 5, 5, 5);
+  fillBoxWith(&box2Msg, 5, 5, 5);
 
   lcm->publish("TEST_CHANNEL_2", &box2Msg);
 

--- a/bridge/repeater_manager.h
+++ b/bridge/repeater_manager.h
@@ -91,7 +91,9 @@ class RepeaterManager {
   /// properly setup the repeater or not.
   /// \param[out] result Always true
   void IgnitionRepeaterServiceHandler(const ignition::msgs::StringMsg& request,
+                                      // NOLINTNEXTLINE(runtime/references) due to ign-transport API
                                       ignition::msgs::Boolean& response,
+                                      // NOLINTNEXTLINE(runtime/references) due to ign-transport API
                                       bool& result);
 
   /// \brief This method is set as a callback of the published service to
@@ -103,7 +105,9 @@ class RepeaterManager {
   /// properly setup the repeater or not.
   /// \param[out] result Always true
   void LCMRepeaterServiceHandler(const ignition::msgs::StringMsg& request,
+                                 // NOLINTNEXTLINE(runtime/references) due to ign-transport API
                                  ignition::msgs::Boolean& response,
+                                 // NOLINTNEXTLINE(runtime/references) due to ign-transport API
                                  bool& result);
 
   /// \brief This method is set as a callback for all LCM channels. Each time


### PR DESCRIPTION
- Addresses the error "Is this a non-const reference? If so, make const or use a pointer" of cpplint
- Adds a local cpplint-exception on the parts where it cannot be addressed (due to the interface required for a function to be used as handler on ignition transport)