### PR TITLE
These are not needed anymore, since they are provided externally.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,6 @@ if (NOT DEFINED BUILD_TESTING)
   set(BUILD_TESTING ON)
 endif ()
 
-# Drake
-set (DRAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}_drake)
-set (DRAKE_LIB_PREFIX ${DRAKE_INSTALL_PREFIX}/lib)
-
 ##########
 # Package Creation:
 


### PR DESCRIPTION
Once we switch over to installing drake into a different location (which is pending https://github.com/RobotLocomotion/drake/pull/7552 getting merged), this will be actively harmful.  Since we don't need it, just remove it now.