### PR TITLE
We don't need the DRAKE_INSTALL_PATH at all anymore.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,6 @@ else (build_errors)
     ${CMAKE_SOURCE_DIR}
     ${PROJECT_BINARY_DIR}
     ${PROJECT_BINARY_DIR}/include
-    ${DRAKE_INSTALL_PREFIX}/include
   )
 
   link_directories(${PROJECT_BINARY_DIR}/src)

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -8,10 +8,6 @@ include (${project_cmake_dir}/FindOS.cmake)
 include (${project_cmake_dir}/Ronn2Man.cmake)
 add_manpage_target()
 
-# Append install_drake path to CMAKE_PREFIX_PATH to enable
-# find_package to find drake-related .cmake files
-list(APPEND CMAKE_PREFIX_PATH ${DRAKE_INSTALL_PREFIX})
-
 ########################################
 # Find drake in unix platforms
 # In Windows we expect a call from configure.bat script with the paths


### PR DESCRIPTION
The combination of this, ToyotaResearchInstitute/delphyne-gui#20, and a cherry-pick of https://github.com/RobotLocomotion/drake/commit/3f83b3a634f0ca03aac609dd957f76d057531d99 onto the https://github.com/osrf/drake/tree/delphyne-use-libprotobuf2 branch should fix #146 .

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>