### PR TITLE
convert from boost python to pybind11

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -36,8 +36,8 @@ delphyne_build_tests(${gtest_sources})
 find_package(PythonLibs 2.7 REQUIRED)
 include_directories(${PYTHON_INCLUDE_DIRS})
 
-find_package(Boost COMPONENTS python REQUIRED)
-include_directories(${Boost_INCLUDE_DIR})
+find_package(pybind11 REQUIRED)
+include_directories(${pybind11_INCLUDE_DIRS})
 
 # Build the simulation support for python bindings as a library.
 add_library(simulation-support
@@ -70,8 +70,8 @@ target_link_libraries(simulation_runner_py
   ${drake_LIBRARIES}
   ${IGNITION-COMMON_LIBRARIES}
   ${IGNITION-TRANSPORT_LIBRARIES}
-  ${Boost_LIBRARIES}
   ${PYTHON_LIBRARIES}
+  ${pybind11_LIBRARIES}
   )
 
 install(TARGETS simulation_runner_py DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/backend/simulation_runner_py.cc
+++ b/backend/simulation_runner_py.cc
@@ -28,11 +28,13 @@
 
 #include <memory>
 
-#include <boost/python.hpp>
 #include <drake/common/find_resource.h>
+#include <pybind11/pybind11.h>
 
 #include "backend/automotive_simulator.h"
 #include "backend/simulation_runner.h"
+
+namespace py = pybind11;
 
 using delphyne::backend::SimulatorRunner;
 
@@ -42,30 +44,26 @@ using delphyne::backend::SimulatorRunner;
 // keep adding python bindings to C++ classes this code will be moved to the
 // python scripts that launches the simulation.
 
-namespace {
 
-std::shared_ptr<SimulatorRunner> SimulatorRunnerFactory() {
-  drake::AddResourceSearchPath(std::string(std::getenv("DRAKE_INSTALL_PATH")) +
-                               "/share/drake");
+PYBIND11_MODULE(simulation_runner_py, m) {
+  py::class_<SimulatorRunner>(m, "SimulatorRunner")
+    .def(py::init([](void) {
 
-  auto simulator =
-      std::make_unique<delphyne::backend::AutomotiveSimulator<double>>();
+      drake::AddResourceSearchPath(std::string(std::getenv("DRAKE_INSTALL_PATH")) +
+                                   "/share/drake");
 
-  // Add a Prius car.
-  drake::automotive::SimpleCarState<double> state;
-  state.set_y(0.0);
-  simulator->AddPriusSimpleCar("0", "DRIVING_COMMAND_0", state);
+      auto simulator =
+          std::make_unique<delphyne::backend::AutomotiveSimulator<double>>();
 
-  // Instantiate the simulator runner and pass the simulator.
-  const double time_step = 0.001;
-  return std::make_shared<SimulatorRunner>(std::move(simulator), time_step);
+      // Add a Prius car.
+      drake::automotive::SimpleCarState<double> state;
+      state.set_y(0.0);
+      simulator->AddPriusSimpleCar("0", "DRIVING_COMMAND_0", state);
+
+      // Instantiate the simulator runner and pass the simulator.
+      const double time_step = 0.001;
+      return std::make_unique<SimulatorRunner>(std::move(simulator), time_step);
+    }))
+    .def("start", &SimulatorRunner::Start)
+  ;
 }
-
-BOOST_PYTHON_MODULE(simulation_runner_py) {
-  boost::python::class_<SimulatorRunner, boost::noncopyable>(
-      "SimulatorRunner", boost::python::no_init)
-      .def("__init__", boost::python::make_constructor(SimulatorRunnerFactory))
-      .def("start", &SimulatorRunner::Start);
-}
-
-}  // namespace


### PR DESCRIPTION
This PR converts the simulator runner bindings from Boost Python to pybind11, the `SimulatorRunnerFactory` is now a lambda defined as the constructor of the resulting Python class. 

Requires https://github.com/osrf/drake/pull/2

Connects to https://github.com/ToyotaResearchInstitute/delphyne/issues/169