### PR TITLE
Remove more lcm

### DIFF
--- a/bridge/duplex_ign_lcm_bridge.cc
+++ b/bridge/duplex_ign_lcm_bridge.cc
@@ -110,8 +110,6 @@ int main(int argc, char* argv[]) {
     exit(1);
   }
 
-  manager.EnableLCMAutodiscovery();
-
   while (!terminatePub) {
     sharedLCM->handleTimeout(100);
   }


### PR DESCRIPTION
Removes repeaters for `DRAKE_VIEWER_STATUS` and `DIRECTOR_TREE_VIEWER_RESPONSE`. It also disables the dynamic creation of LCM->IGN repeaters.