### PR TITLE
Change SetInputPortValue to FixInputPort in the tests.

### DIFF
--- a/backend/test/ign_publisher_system_test.cc
+++ b/backend/test/ign_publisher_system_test.cc
@@ -135,10 +135,9 @@ TEST_F(IgnPublisherSystemTest, PublishTest) {
   auto lcm_msg = get_preloaded_draw_msg();
 
   // Configures context's input with the pre-loaded message.
-  context->SetInputPortValue(
-      0, std::make_unique<drake::systems::FreestandingInputPortValue>(
-             std::make_unique<drake::systems::Value<drake::lcmt_viewer_draw>>(
-                 lcm_msg)));
+  context->FixInputPort(
+      0, std::make_unique<drake::systems::Value<drake::lcmt_viewer_draw>>(
+             lcm_msg));
 
   // Makes the IgnPublisherSystem to publish the message.
   ign_publisher_->Publish(*context.get());


### PR DESCRIPTION
In newer drake versions, SetInputPortValue ends up being
marked protected, so we can no longer call it directly.
However, FixInputPort is available both in this earlier
version of drake, and is still public in later versions,
so it is safe to use.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>