### PR TITLE
Disable python callbacks when simulation is paused

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,9 @@ There's an automated script that will take care of building the project, running
 ```
 ./tools/run_coverage.sh
 ```
+
+## Instructions for running tests
+All the available tests, both C++ and Python, can be run by calling a single helper script. It can be invoked as follows:
+```
+./tools/run_tests.sh
+```

--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -89,3 +89,6 @@ install(FILES utils.py DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python2.7/site-pa
 install(PROGRAMS python_examples/python_bindings_example.py DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 install(PROGRAMS python_examples/keyboard_controlled_simulation.py DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 install(PROGRAMS python_examples/paused_mode_example.py DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+
+# Python tests
+install(PROGRAMS test/simulation_runner_py_test.py DESTINATION ${CMAKE_BINARY_DIR}/backend)

--- a/backend/simulation_runner.cc
+++ b/backend/simulation_runner.cc
@@ -183,8 +183,8 @@ void SimulatorRunner::RunSimulationStep() {
   }
 
   // This if is here so that we only grab the python global interpreter lock
-  // if there is at least one callback.
-  if (callbacks.size() > 0) {
+  // if there is at least one callback and the simulation is unpaused.
+  if (callbacks.size() > 0 && !paused_) {
     // 1. Acquires the lock to the python interpreter.
     py::gil_scoped_acquire acquire;
     // 2. Performs the callbacks.

--- a/backend/test/simulation_runner_py_test.py
+++ b/backend/test/simulation_runner_py_test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+import unittest
+from simulation_runner_py import (
+    AutomotiveSimulator,
+    SimpleCarState,
+    SimulatorRunner
+)
+
+
+class TestSimulationRunnerPy(unittest.TestCase):
+    """
+    Test units for the simulator_runner python bindings.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Setups variables and objects common across all tests."""
+        # Call parent class' init method.
+        super(TestSimulationRunnerPy, self).__init__(*args, **kwargs)
+        # Initialize class variables.
+        self.simulator = AutomotiveSimulator()
+        self.state = SimpleCarState()
+        self.simulator.AddPriusSimpleCar("0", "DRIVING_TEST", self.state)
+        self.simulation_step = 0.001
+        self.callback_called = False
+
+    def setUp(self):
+        """Initializes variables before running each test case."""
+        # Initialize callback flag.
+        self.callback_called = False
+
+    def callback_test(self):
+        """Sets a flag to True."""
+        self.callback_called = True
+
+    def test_callback_when_paused(self):
+        """Creates a simulator runner in paused mode and runs a simulation step,
+        verifying that the registered python callback haven't been called.
+        """
+        # Creates a simulator runner that starts in paused mode.
+        start_paused = True
+        runner = SimulatorRunner(
+            self.simulator, self.simulation_step, start_paused)
+        # Register a step callback.
+        runner.AddStepCallback(self.callback_test)
+        # Starts the simulator runner.
+        runner.Start()
+        # Run a simulation step.
+        runner.RunSimulationStep()
+
+        # Checks that callback hasn't been called.
+        self.assertFalse(self.callback_called)
+
+    def test_callback_when_not_paused(self):
+        """Creates a simulator runner and runs a simulation step,
+        verifying that the registered python callback is called.
+        """
+        # Creates a simulator runner.
+        runner = SimulatorRunner(self.simulator, self.simulation_step)
+        # Register a step callback.
+        runner.AddStepCallback(self.callback_test)
+
+        # Checks that callback hasn't been called
+        # before running a simulation step.
+        self.assertFalse(self.callback_called)
+
+        # Run a simulation step.
+        runner.RunSimulationStep()
+
+        # Checks that callback has been called
+        # after a simulation step.
+        self.assertTrue(self.callback_called)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -3,6 +3,11 @@
 set -e
 
 cd $DELPHYNE_WS_DIR/build/delphyne
+
+printf "\nRunning C++ tests:\n"
 cmake ../../src/delphyne -DCMAKE_INSTALL_PREFIX=../../install
 make -j$( getconf _NPROCESSORS_ONLN )
 make test
+
+printf "\nRunning Python tests:\n"
+python -m unittest discover backend "*_test.py"


### PR DESCRIPTION
Fixes #192 
- One-line change that avoids the simulator to execute python callbacks when it's paused.
- Added tests