### PR TITLE
Adds automatic documentation generator for python modules

### DIFF
--- a/backend/python_examples/README.md
+++ b/backend/python_examples/README.md
@@ -1,36 +1,30 @@
 # Python examples
 
-These examples are intended to demonstrate how to use the python bindings of the simulation runner.
+These examples are intended to demonstrate how to use the python bindings of the
+simulation runner.
 
-For all the examples below it's assumed that the Delphyne backend was successfully built with CMake,
-as shown in the instructions [here](https://github.com/ToyotaResearchInstitute/delphyne-gui/blob/master/README.md#build-delphyne-back-end).
+For all the examples below it's assumed that the Delphyne backend was successfully
+built with CMake, as shown in the instructions
+[here](https://github.com/ToyotaResearchInstitute/delphyne-gui/blob/master/README.md#build-delphyne-back-end) .
+<h1 id="python_bindings_example">python_bindings_example</h1>
 
-# paused_mode_example.py
+This is a minimal example of starting an automotive simulation using a
+python binding to the C++ `SimulatorRunner` class.
 
-This example show how to use the `SimulationRunner`'s (optional) third constructor argument to start in pause mode.
+Note that this is not a configurable demo, it will just create a sample
+simulation with a prius car that can be driven around.
 
-```
-$ cd <delphyne_ws>/install/bin
-$ ./paused_mode_example.py
-```
+As we add more python bindings to the C++ classes we will start doing more
+interesting scripts.
 
-This command will spawn a visualizer instance and start the simulation in paused mode.
+<h1 id="keyboard_controlled_simulation">keyboard_controlled_simulation</h1>
 
-## Unpausing the simulation
 
-- At this moment, the only available way of achieving this is by making use of a `WorldControl` service, publishing a message with the right content into the `/world_control` channel:
-
-```
-$ cd <delphyne_ws>/install/bin
-$ ./ign service --service /world_control --reqtype ignition.msgs.WorldControl --reptype ignition.msgs.Boolean --timeout 500 --req 'pause: false'
-```
-
-- An alternative way will be to use the `TimePanel` widget in the visualizer (currently under development), which will allow to control the simulation with Play / Pause / Step buttons from the GUI.
-
-# keyboard_controlled_simulation.py
-This example shows how to use the keyboard events to control the advance of a simulation. The simulation will open the usual simple car
-in the center of the scene, which can be driven using the keyboard on the GUI's teleop widget. However, by switching to the console, we
-can play/pause/step/quit the simulation.
+This example shows how to use the keyboard events to control the advance of
+a simulation. The simulation will open the usual simple car in the center of
+the scene, which can be driven using the keyboard on the GUI's teleop widget.
+However, by switching to the console, we can `play`/`pause`/`step`/`quit` the
+simulation.
 
 ```
 $ cd <delphyne_ws>/install/bin
@@ -44,3 +38,34 @@ $ ./keyboard_controlled_simulation.py
 <`s`> will step the simulation once if paused.
 
 <`q`> will stop the simulation and quit the demo.
+
+<h1 id="paused_mode_example">paused_mode_example</h1>
+
+
+This example show how to use the `SimulationRunner`'s (optional) third
+constructor argument to start in pause mode.
+
+```
+$ cd <delphyne_ws>/install/bin
+$ ./paused_mode_example.py
+```
+
+This command will spawn a visualizer instance and start the simulation
+in paused mode.
+
+ ## Unpausing the simulation
+
+- At this moment, the only available way of achieving this is by making
+use of a `WorldControl` service, publishing a message with the right
+content into the `/world_control` channel:
+
+```
+$ cd <delphyne_ws>/install/bin
+$ ./ign service --service /world_control --reqtype ignition.msgs.WorldControl --reptype ignition.msgs.Boolean --timeout 500 --req 'pause: false'
+```
+
+- An alternative way will be to use the `TimePanel` widget in the visualizer
+(currently under development), which will allow to control the simulation with
+`Play` / `Pause` / `Step` buttons from the GUI.
+
+

--- a/backend/python_examples/keyboard_controlled_simulation.py
+++ b/backend/python_examples/keyboard_controlled_simulation.py
@@ -1,8 +1,25 @@
 #!/usr/bin/env python2.7
-
-"""This is an example of running an automotive simulator and to control the
-advance of the simulation by pressing specific keys on the keyboard.
 """
+This example shows how to use the keyboard events to control the advance of
+a simulation. The simulation will open the usual simple car in the center of
+the scene, which can be driven using the keyboard on the GUI's teleop widget.
+However, by switching to the console, we can `play`/`pause`/`step`/`quit` the
+simulation.
+
+```
+$ cd <delphyne_ws>/install/bin
+$ ./keyboard_controlled_simulation.py
+```
+
+ The supported keys for the demo:
+
+<`p`> will pause the simulation if running and vice-versa.
+
+<`s`> will step the simulation once if paused.
+
+<`q`> will stop the simulation and quit the demo.
+"""
+
 
 # Copyright 2017 Open Source Robotics Foundation
 #

--- a/backend/python_examples/paused_mode_example.py
+++ b/backend/python_examples/paused_mode_example.py
@@ -1,27 +1,32 @@
 #!/usr/bin/env python2.7
 
-"""This example show how to use the SimulationRunner's (optional)
-third constructor argument to start in pause mode.
+"""
+This example show how to use the `SimulationRunner`'s (optional) third
+constructor argument to start in pause mode.
 
+```
 $ cd <delphyne_ws>/install/bin
 $ ./paused_mode_example.py
+```
 
 This command will spawn a visualizer instance and start the simulation
 in paused mode.
 
-Unpausing the simulation
+ ## Unpausing the simulation
 
 - At this moment, the only available way of achieving this is by making
-use of a WorldControl service, publishing a message with the right
-content into the /world_control channel:
+use of a `WorldControl` service, publishing a message with the right
+content into the `/world_control` channel:
 
+```
 $ cd <delphyne_ws>/install/bin
 $ ./ign service --service /world_control --reqtype ignition.msgs.WorldControl \
 --reptype ignition.msgs.Boolean --timeout 500 --req 'pause: false'
+```
 
-- An alternative way will be to use the TimePanel widget in the visualizer
-(currently under development), which will allow to control the simulation
-with Play / Pause / Step buttons from the GUI.
+- An alternative way will be to use the `TimePanel` widget in the visualizer
+(currently under development), which will allow to control the simulation with
+`Play` / `Pause` / `Step` buttons from the GUI.
 
 """
 

--- a/backend/python_examples/python_bindings_example.py
+++ b/backend/python_examples/python_bindings_example.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2.7
 
 """This is a minimal example of starting an automotive simulation using a
-python binding to the C++ SimulatorRunner class.
+python binding to the C++ `SimulatorRunner` class.
 
 Note that this is not a configurable demo, it will just create a sample
 simulation with a prius car that can be driven around.

--- a/tools/generate_python_docs.sh
+++ b/tools/generate_python_docs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+# Enables the python interpreter to find simulation_runner.so .
+PYTHONPATH=$PYTHONPATH:/home/alexis/delphyne_ws/install/bin
+
+# Sets the path to the generated readme.
+PATH_TO_README=$DELPHYNE_WS_DIR/src/delphyne/backend/python_examples/README.md
+
+# Remove previous version of README.md .
+rm -f $PATH_TO_README && touch $PATH_TO_README
+
+cat tools/python_examples_md_template.in > $PATH_TO_README
+
+cd backend/python_examples
+
+# Converts a python module docstring into markdown and appends it to the README.
+find . -iname '*.py' -printf '%f\n' | while read file ; do
+  module_name=$(echo $file | cut -f 1 -d '.')
+  echo "Processing $module_name"
+  pydocmd simple $module_name >> $PATH_TO_README
+done

--- a/tools/python_examples_md_template.in
+++ b/tools/python_examples_md_template.in
@@ -1,0 +1,8 @@
+# Python examples
+
+These examples are intended to demonstrate how to use the python bindings of the
+simulation runner.
+
+For all the examples below it's assumed that the Delphyne backend was successfully
+built with CMake, as shown in the instructions
+[here](https://github.com/ToyotaResearchInstitute/delphyne-gui/blob/master/README.md#build-delphyne-back-end) .


### PR DESCRIPTION
- Adds a bash script that iterates through the python files, generating a markdown formatted text as output.
- Updated docstrings in python examples so that the automatically-generated README have the same content as the previous one.
- Updated `backend/python_examples/README.md` itself with an automatically-generated version.

Note: this PR should go hand-in-hand with [ToyotaResearchInstitute/delphyne-gui#40](https://github.com/ToyotaResearchInstitute/delphyne-gui/pull/40)