### PR TITLE
Add tests for AbstractInputToIgnConverter

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -46,18 +46,17 @@ install(TARGETS automotive-demo DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 delphyne_build_tests(${gtest_sources})
 
 # Helpers
-add_library(test-helpers
+add_library(test_helpers
     test/helpers.cc)
 
-target_link_libraries(test-helpers
-  libgtest.a
-  libgtest_main.a
+target_link_libraries(test_helpers
+  gtest
+  gtest_main
   ${drake_LIBRARIES}
-  ${IGNITION-COMMON_LIBRARIES}
-  ${IGNITION-TRANSPORT_LIBRARIES}
+  ${IGNITION-MSGS_LIBRARIES}
 )
 
-target_include_directories(test-helpers PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(test_helpers PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 # ----------------------------------------
 # Python bindings
 

--- a/backend/test/abstract_input_to_ign_converter_test.cc
+++ b/backend/test/abstract_input_to_ign_converter_test.cc
@@ -28,11 +28,11 @@
 
 #include "backend/abstract_input_to_ign_converter.h"
 #include "backend/ign_publisher_system.h"
-#include "backend/test/helpers.cc"
-
-#include "gtest/gtest.h"
+#include "backend/test/helpers.h"
 
 #include <drake/lcmt_viewer_draw.hpp>
+
+#include "gtest/gtest.h"
 
 #include <ignition/msgs.hh>
 
@@ -41,7 +41,7 @@ namespace backend {
 
 // \brief Checks that an lcm message from the input port is
 // correctly translated into its ignition-msgs counterpart.
-GTEST_TEST(AbstractInputToIgnConverterTest, TestProcessInputWithValidTypes) {
+GTEST_TEST(AbstractInputToIgnConverterTest, TestProcessInput) {
   // Converter required by the ignition publisher.
   auto converter =
       std::make_unique<AbstractInputToIgnConverter<drake::lcmt_viewer_draw,
@@ -61,29 +61,28 @@ GTEST_TEST(AbstractInputToIgnConverterTest, TestProcessInputWithValidTypes) {
   std::unique_ptr<drake::systems::Context<double>> context =
       ign_publisher->CreateDefaultContext();
 
-  auto lcm_msg{get_preloaded_draw_msg()};
-
-  auto ign_msg{std::make_unique<ignition::msgs::Model_V>()};
+  const drake::lcmt_viewer_draw lcm_msg{test::BuildPreloadedDrawMsg()};
 
   // Configures context's input with the pre-loaded message.
   context->FixInputPort(
       0, std::make_unique<drake::systems::Value<drake::lcmt_viewer_draw>>(
              lcm_msg));
 
-  int kPortIndex{0};
+  const int kPortIndex{0};
 
   // Calls the ProcessInput method from our test_converter object, since
   // the other converter now belongs to the ign_publisher object.
+  auto ign_msg = std::make_unique<ignition::msgs::Model_V>();
   test_converter->ProcessInput(ign_publisher.get(), *context, kPortIndex,
                                ign_msg.get());
 
   // Check translation's correctness.
-  CheckMsgTranslation(lcm_msg, *ign_msg);
+  EXPECT_TRUE(test::CheckMsgTranslation(lcm_msg, *ign_msg));
 }
 
 // \brief Checks that the DeclareInputPort methods
 // adds another input port to the IgnPublisherSystem.
-GTEST_TEST(AbstractInputToIgnConverterTest, TestProcessInputWithInvalidTypes) {
+GTEST_TEST(AbstractInputToIgnConverterTest, TestDeclareInputPort) {
   // Converter required by the ignition publisher.
   auto converter =
       std::make_unique<AbstractInputToIgnConverter<drake::lcmt_viewer_draw,

--- a/backend/test/helpers.h
+++ b/backend/test/helpers.h
@@ -1,0 +1,87 @@
+// Copyright 2018 Open Source Robotics Foundation
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <drake/lcmt_viewer_draw.hpp>
+
+#include <gtest/gtest.h>
+
+#include <ignition/msgs.hh>
+
+namespace delphyne {
+namespace test {
+
+// Generates a pre-loaded lcmt_viewer_draw message.
+//
+// @return a loaded lcmt_viewer_draw message.
+__attribute__((visibility("default"))) drake::lcmt_viewer_draw
+BuildPreloadedDrawMsg();
+
+// Asserts that all the array-iterable values from
+// lcm_msg matches the content of the ign_models object.
+//
+// @param lcm_msg An lcm viewer draw message with the desired values.
+// @param ign_models An ignition messages Model_V with the translated values.
+// @return a google test's AssertionResult.
+__attribute__((visibility("default")))::testing::AssertionResult
+CheckMsgTranslation(const drake::lcmt_viewer_draw& lcm_msg,
+                    const ignition::msgs::Model_V& ign_models);
+
+// Asserts that all the array-iterable values from
+// lcm_msg matches the content of the scene object.
+//
+// @param lcm_msg An lcm viewer draw message with the desired values.
+// @param ign_models An ignition messages Scene with the translated values.
+// @return a google test's AssertionResult.
+__attribute__((visibility("default")))::testing::AssertionResult
+CheckMsgTranslation(const drake::lcmt_viewer_draw& lcm_msg,
+                    const ignition::msgs::Scene& scene);
+
+// Asserts that the position values found on the original lcm message are
+// equivalent to the values found on the translated ignition object.
+//
+// @param pose An ignition messages pose object with the translated values.
+// @param lcm_msg An lcm viewer draw message with the desired values.
+// @return a google test's AssertionResult.
+::testing::AssertionResult CheckPositionTranslation(
+    const ignition::msgs::Pose& pose, const drake::lcmt_viewer_draw& lcm_msg,
+    int lcm_index, double tolerance);
+
+// Asserts that the position values found on the original lcm message are
+// equivalent to the values found on the translated ignition object.
+//
+// @param pose An ignition messages pose object with the translated values.
+// @param lcm_msg An lcm viewer draw message with the desired values.
+// @return a google test's AssertionResult.
+::testing::AssertionResult CheckOrientationTranslation(
+    const ignition::msgs::Pose& pose, const drake::lcmt_viewer_draw& lcm_msg,
+    int lcm_index, double tolerance);
+
+}  // namespace test
+}  // namespace delphyne

--- a/backend/test/ign_publisher_system_test.cc
+++ b/backend/test/ign_publisher_system_test.cc
@@ -28,7 +28,7 @@
 
 #include "backend/abstract_input_to_ign_converter.h"
 #include "backend/ign_publisher_system.h"
-#include "backend/test/helpers.cc"
+#include "backend/test/helpers.h"
 
 #include "gtest/gtest.h"
 
@@ -88,7 +88,7 @@ TEST_F(IgnPublisherSystemTest, PublishTest) {
       ign_publisher_->CreateDefaultContext();
 
   // Fills the lcm message with sample data.
-  auto lcm_msg = get_preloaded_draw_msg();
+  const auto lcm_msg = test::BuildPreloadedDrawMsg();
 
   // Configures context's input with the pre-loaded message.
   context->FixInputPort(
@@ -105,7 +105,7 @@ TEST_F(IgnPublisherSystemTest, PublishTest) {
 
   // Verifies the equivalence of the original lcm message and
   // the received ignition-transport message.
-  CheckMsgTranslation(lcm_msg, ign_msg_);
+  EXPECT_TRUE(test::CheckMsgTranslation(lcm_msg, ign_msg_));
 }
 
 }  // namespace backend

--- a/backend/test/scene_system_test.cc
+++ b/backend/test/scene_system_test.cc
@@ -27,7 +27,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "backend/scene_system.h"
-#include "backend/test/helpers.cc"
+#include "backend/test/helpers.h"
 
 #include "gtest/gtest.h"
 
@@ -40,46 +40,6 @@
 
 namespace delphyne {
 namespace backend {
-
-// Checks that all the array-iterable values from
-// lcmt_viewer_draw matches their ignition counterpart.
-void CheckMsgTranslation(const drake::lcmt_viewer_draw& lcm_msg,
-                         const ignition::msgs::Scene& scene) {
-  for (int i = 0; i < lcm_msg.num_links; i++) {
-    // Step 1: Checks there is a corresponding ignition model for the LCM link.
-    bool found = false;
-    ignition::msgs::Model model;
-    for (int j = 0; j < scene.model_size(); ++j) {
-      if (scene.model(j).id() == int64_t{lcm_msg.robot_num[i]}) {
-        model = scene.model(j);
-        found = true;
-      }
-    }
-    ASSERT_TRUE(found);
-
-    // Step 2: Checks there is a corresponding ignition link for the LCM link.
-    found = false;
-    ignition::msgs::Link link;
-    for (int j = 0; j < model.link_size(); ++j) {
-      if (model.link(j).name() == lcm_msg.link_name[i]) {
-        link = model.link(j);
-        found = true;
-      }
-    }
-    ASSERT_TRUE(found);
-
-    // Step 3: Gets the pose and compares the values.
-    const ignition::msgs::Pose pose = link.pose();
-
-    EXPECT_EQ(pose.position().x(), lcm_msg.position[i][0]);
-    EXPECT_EQ(pose.position().y(), lcm_msg.position[i][1]);
-    EXPECT_EQ(pose.position().z(), lcm_msg.position[i][2]);
-    EXPECT_EQ(pose.orientation().w(), lcm_msg.quaternion[i][0]);
-    EXPECT_EQ(pose.orientation().x(), lcm_msg.quaternion[i][1]);
-    EXPECT_EQ(pose.orientation().y(), lcm_msg.quaternion[i][2]);
-    EXPECT_EQ(pose.orientation().z(), lcm_msg.quaternion[i][3]);
-  }
-}
 
 class SceneSystemTest : public ::testing::Test {
  public:
@@ -101,28 +61,6 @@ class SceneSystemTest : public ::testing::Test {
     handler_called_ = false;
   }
 
-  drake::lcmt_viewer_draw get_preloaded_draw_msg() {
-    drake::lcmt_viewer_draw msg;
-    msg.timestamp = 0;
-    msg.num_links = 1;
-    msg.link_name.resize(msg.num_links);
-    msg.link_name[0] = "box";
-    msg.robot_num.resize(1);
-    msg.robot_num[0] = 1;
-    msg.position.resize(1);
-    msg.position[0].resize(3);
-    msg.position[0][0] = 0.0;
-    msg.position[0][1] = 0.0;
-    msg.position[0][2] = 0.0;
-    msg.quaternion.resize(1);
-    msg.quaternion[0].resize(4);
-    msg.quaternion[0][0] = 0.0;
-    msg.quaternion[0][1] = 0.0;
-    msg.quaternion[0][2] = 0.0;
-    msg.quaternion[0][3] = 1.0;
-    return msg;
-  }
-
  private:
   void SubscriberMockCallback(const ignition::msgs::Scene& message) {
     scene_msg_ = message;
@@ -137,7 +75,7 @@ TEST_F(SceneSystemTest, PublishTest) {
       scene_publisher_->CreateDefaultContext();
 
   // Fills the lcm message with sample data.
-  auto lcm_msg = get_preloaded_draw_msg();
+  const auto lcm_msg = test::BuildPreloadedDrawMsg();
 
   // Configures context's input with the pre-loaded message.
   context->FixInputPort(
@@ -154,7 +92,7 @@ TEST_F(SceneSystemTest, PublishTest) {
 
   // Verifies the equivalence of the original lcm message and
   // the received ignition-transport message.
-  CheckMsgTranslation(lcm_msg, scene_msg_);
+  EXPECT_TRUE(test::CheckMsgTranslation(lcm_msg, scene_msg_));
 }
 
 }  // namespace backend

--- a/bridge/test/lcm_to_ign_translation_test.cc
+++ b/bridge/test/lcm_to_ign_translation_test.cc
@@ -26,11 +26,16 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "bridge/lcm_to_ign_translation.h"
+
 #include <iostream>
+
+#include "backend/test/helpers.h"
+
 #include <gtest/gtest.h>
+
 #include <ignition/msgs.hh>
 
-#include "bridge/lcm_to_ign_translation.h"
 
 namespace delphyne {
 namespace bridge {
@@ -61,43 +66,6 @@ class ViewerDrawTest : public ::testing::Test {
     drawMsg.position[1] = {4.0, 5.0, 6.0};
     drawMsg.quaternion[1] = {8.0, 7.0, 6.0, 5.0};
   }
-
-  //////////////////////////////////////////////////
-  /// \brief Checks that all the array-iterable values from
-  /// lcmt_viewer_draw are matching their ignition counterpart
-  void CheckMsgTranslation(const drake::lcmt_viewer_draw& lcmMsg,
-                           const ignition::msgs::Model_V& ignModel) {
-    for (int i = 0; i < lcmMsg.num_links; i++) {
-      // Step 1: Check there is a corresponding ignition model for the LCM link
-      ignition::msgs::Model model;
-      for (int j = 0; j < ignModel.models_size(); ++j) {
-        if (ignModel.models(j).id() == (unsigned)lcmMsg.robot_num[i]) {
-          model = ignModel.models(j);
-        }
-      }
-      ASSERT_NE(nullptr, &model);
-
-      // Step 2: Check there is a corresponding ignition link for the LCM link
-      ignition::msgs::Link link;
-      for (int j = 0; j < model.link_size(); ++j) {
-        if (model.link(j).name() == lcmMsg.link_name[i]) {
-          link = model.link(j);
-        }
-      }
-      ASSERT_NE(nullptr, &link);
-
-      // Step 3: Get the pose and compare the values
-      ignition::msgs::Pose pose = link.pose();
-
-      EXPECT_EQ(pose.position().x(), lcmMsg.position[i][0]);
-      EXPECT_EQ(pose.position().y(), lcmMsg.position[i][1]);
-      EXPECT_EQ(pose.position().z(), lcmMsg.position[i][2]);
-      EXPECT_EQ(pose.orientation().w(), lcmMsg.quaternion[i][0]);
-      EXPECT_EQ(pose.orientation().x(), lcmMsg.quaternion[i][1]);
-      EXPECT_EQ(pose.orientation().y(), lcmMsg.quaternion[i][2]);
-      EXPECT_EQ(pose.orientation().z(), lcmMsg.quaternion[i][3]);
-    }
-  }
 };
 
 //////////////////////////////////////////////////
@@ -127,7 +95,7 @@ TEST_F(ViewerDrawTest, TestOnePoseInPosesStamp) {
   drawMsg.quaternion.resize(1);
   ignition::msgs::Model_V ignMsg;
   lcmToIgn(drawMsg, &ignMsg);
-  CheckMsgTranslation(drawMsg, ignMsg);
+  EXPECT_TRUE(test::CheckMsgTranslation(drawMsg, ignMsg));
 }
 
 //////////////////////////////////////////////////
@@ -147,7 +115,7 @@ TEST_F(ViewerDrawTest, TestThreePosesInPosesStamp) {
   drawMsg.quaternion[2] = {12.0, 11.0, 10.0, 9.0};
   ignition::msgs::Model_V ignMsg;
   lcmToIgn(drawMsg, &ignMsg);
-  CheckMsgTranslation(drawMsg, ignMsg);
+  EXPECT_TRUE(test::CheckMsgTranslation(drawMsg, ignMsg));
 }
 
 //////////////////////////////////////////////////

--- a/cmake/TestUtils.cmake
+++ b/cmake/TestUtils.cmake
@@ -41,7 +41,7 @@ macro (delphyne_build_tests)
       pthread
       delphyne_protobuf_msgs
       delphyne_lcm_to_ign
-      test-helpers
+      test_helpers
     )
 
     # Remove a warning in GTest.


### PR DESCRIPTION
Addresses a part of #215 .
In addition, refactored the commonly-used generators/checkers into a test's helper library.