### PR TITLE
Add missing tests for converters part 2

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -12,8 +12,8 @@ set (sources
   scene_system.cc
   simple_car_state_input_to_ign_converter.h
   simulation_runner.cc
-  vector_input_to_ign_converter.h
   system.h
+  vector_input_to_ign_converter.h
 )
 
 set (gtest_sources

--- a/backend/automotive_simulator.cc
+++ b/backend/automotive_simulator.cc
@@ -34,10 +34,6 @@
 #include <map>
 #include <utility>
 
-#include "backend/agent_plugin_loader.h"
-#include "backend/linb-any"
-#include "backend/system.h"
-
 #include "drake/automotive/gen/driving_command.h"
 #include "drake/automotive/gen/driving_command_translator.h"
 #include "drake/automotive/gen/maliput_railcar_state_translator.h"
@@ -65,9 +61,12 @@
 #include "drake/systems/primitives/multiplexer.h"
 
 #include "backend/abstract_input_to_ign_converter.h"
+#include "backend/agent_plugin_loader.h"
 #include "backend/automotive_simulator.h"
 #include "backend/input_port_to_ign_converter.h"
+#include "backend/linb-any"
 #include "backend/simple_car_state_input_to_ign_converter.h"
+#include "backend/system.h"
 
 namespace delphyne {
 

--- a/backend/simple_car_state_input_to_ign_converter.h
+++ b/backend/simple_car_state_input_to_ign_converter.h
@@ -31,11 +31,11 @@
 #include <memory>
 #include <vector>
 
-#include "backend/vector_input_to_ign_converter.h"
-
 #include <drake/automotive/simple_car.h>
 
 #include <protobuf/simple_car_state.pb.h>
+
+#include "backend/vector_input_to_ign_converter.h"
 
 namespace delphyne {
 namespace backend {

--- a/backend/system.h
+++ b/backend/system.h
@@ -62,10 +62,10 @@
 
 
 /// \def DELPHYNE_ASSERT
-/// Use to declare an assertion. Will quit execution otherwise.
+/// Used to declare an assertion. Will quit execution otherwise.
 
 /// \def DELPHYNE_DEMAND
-/// Use to declare an demand. Will quit execution otherwise.
+/// Used to declare a demand. Will quit execution otherwise.
 
 #define DELPHYNE_ASSERT(condition) DRAKE_ASSERT(condition)
 #define DELPHYNE_DEMAND(condition) DRAKE_DEMAND(condition)

--- a/backend/test/abstract_input_to_ign_converter_test.cc
+++ b/backend/test/abstract_input_to_ign_converter_test.cc
@@ -27,8 +27,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "backend/abstract_input_to_ign_converter.h"
-#include "backend/ign_publisher_system.h"
-#include "backend/test/helpers.h"
 
 #include <drake/lcmt_viewer_draw.hpp>
 #include <drake/systems/framework/framework_common.h>
@@ -36,6 +34,9 @@
 #include "gtest/gtest.h"
 
 #include <ignition/msgs.hh>
+
+#include "backend/ign_publisher_system.h"
+#include "backend/test/helpers.h"
 
 namespace delphyne {
 namespace backend {
@@ -109,7 +110,7 @@ GTEST_TEST(AbstractInputToIgnConverterTest, TestDeclareInputPort) {
   // A new input must have been added to the system.
   EXPECT_EQ(ign_publisher->get_num_input_ports(), 2);
 
-  // And it must be of type abstract.
+  // And it must be of abstract type.
   EXPECT_EQ(ign_publisher->get_input_port(1).get_data_type(), drake::systems::kAbstractValued);
 
 }

--- a/backend/test/helpers.cc
+++ b/backend/test/helpers.cc
@@ -26,16 +26,17 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <string>
+#include "backend/helpers.h"
 
-#include "backend/test/helpers.h"
-#include "backend/system.h"
+#include <string>
 
 #include <drake/lcmt_viewer_draw.hpp>
 
 #include <gtest/gtest.h>
 
 #include <ignition/msgs.hh>
+
+#include "backend/system.h"
 
 namespace delphyne {
 namespace test {

--- a/backend/test/simple_car_state_input_to_ign_converter_test.cc
+++ b/backend/test/simple_car_state_input_to_ign_converter_test.cc
@@ -27,7 +27,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "backend/simple_car_state_input_to_ign_converter.h"
-#include "backend/test/helpers.h"
 
 #include <drake/automotive/gen/simple_car_state.h>
 #include <drake/automotive/gen/simple_car_state_translator.h>
@@ -35,6 +34,8 @@
 #include "gtest/gtest.h"
 
 #include <protobuf/simple_car_state.pb.h>
+
+#include "backend/test/helpers.h"
 
 namespace delphyne {
 namespace backend {
@@ -44,7 +45,7 @@ namespace test {
 // processed and translated into its ignition-msgs counterpart.
 GTEST_TEST(SimpleCarStateInputToIgnConverterTest, TestVectorToIgn) {
   // The size of the vector.
-  const int kSize = 1;
+  const int kSize{1};
 
   // Converter required by the ignition publisher.
   auto converter = std::make_unique<SimpleCarStateInputToIgnConverter>(kSize);
@@ -65,18 +66,24 @@ GTEST_TEST(SimpleCarStateInputToIgnConverterTest, TestVectorToIgn) {
   std::unique_ptr<drake::systems::Context<double>> context =
       ign_publisher->CreateDefaultContext();
 
+  // Values used to check against.
+  const int kPortIndex{0};
+  const double kTimeSecs{123.456};
+  const double kExpectedX{1.9};
+  const double kExpectedY{2.8};
+  const double kExpectedHeading{3.7};
+  const double kExpectedVelocity{4.6};
+
   // Sets time value, since it'll be included as part of the
   // ignition message in the translation.
-  context->set_time(123.456);
+  context->set_time(kTimeSecs);
 
   // Loads the SimpleCarState message with constant values.
   drake::automotive::SimpleCarState<double> car_state;
-  car_state.set_x(1.9);
-  car_state.set_y(2.8);
-  car_state.set_heading(3.7);
-  car_state.set_velocity(4.6);
-
-  const int kPortIndex{0};
+  car_state.set_x(kExpectedX);
+  car_state.set_y(kExpectedY);
+  car_state.set_heading(kExpectedHeading);
+  car_state.set_velocity(kExpectedVelocity);
 
   // Configures context's input with the pre-loaded message.
   context->FixInputPort(
@@ -97,10 +104,10 @@ GTEST_TEST(SimpleCarStateInputToIgnConverterTest, TestVectorToIgn) {
   // Asserts that the vector message has been translated correctly.
   EXPECT_EQ(ign_msg->time().sec(), 123);
   EXPECT_EQ(ign_msg->time().nsec(), 456000000);
-  EXPECT_EQ(ign_msg->x(), 1.9);
-  EXPECT_EQ(ign_msg->y(), 2.8);
-  EXPECT_EQ(ign_msg->heading(), 3.7);
-  EXPECT_EQ(ign_msg->velocity(), 4.6);
+  EXPECT_EQ(ign_msg->x(), kExpectedX);
+  EXPECT_EQ(ign_msg->y(), kExpectedY);
+  EXPECT_EQ(ign_msg->heading(), kExpectedHeading);
+  EXPECT_EQ(ign_msg->velocity(), kExpectedVelocity);
 }
 
 }  // namespace test

--- a/backend/test/vector_input_to_ign_converter_test.cc
+++ b/backend/test/vector_input_to_ign_converter_test.cc
@@ -35,10 +35,11 @@
 
 #include <protobuf/simple_car_state.pb.h>
 
-using drake::automotive::SimpleCarStateIndices;
-
 namespace delphyne {
 namespace backend {
+
+using drake::automotive::SimpleCarStateIndices;
+
 namespace test {
 
 // Defines a VectorToIgnConverter inherited class that implements the
@@ -53,8 +54,7 @@ class MockedVectorInputToIgnConverter
   void vectorToIgn(const VectorBase<double>& input_vector, double time,
                    ignition::msgs::SimpleCarState* ign_message) override {
     // Sets a fixed time value to the ign_message.
-    const int64_t secs = 12345;
-    ign_message->mutable_time()->set_sec(secs);
+    ign_message->mutable_time()->set_sec(12345);
   }
 };
 

--- a/backend/vector_input_to_ign_converter.h
+++ b/backend/vector_input_to_ign_converter.h
@@ -35,11 +35,10 @@
 #include "backend/input_port_to_ign_converter.h"
 #include "backend/system.h"
 
-
-using drake::systems::VectorBase;
-
 namespace delphyne {
 namespace backend {
+
+using drake::systems::VectorBase;
 
 /// This class is a specialization of InputPortToIgnConverter that handles
 /// only VectorBase input ports. Concrete subclasses only need to define


### PR DESCRIPTION
This PR addresses the second and last part of #215.

It includes:
- Tests for the `VectorInputToIgnConverter` class.
- Tests for the `SimpleCarStateInputToIgnConverter` class.
- Fixes some missing dependencies and a translation in the `simple_car_state_input_to_ign_converter.h` file.
