### PR TITLE
Launch the bridge when running paused_mode_example

### DIFF
--- a/backend/python_examples/paused_mode_example.py
+++ b/backend/python_examples/paused_mode_example.py
@@ -68,6 +68,7 @@ from simulation_runner_py import SimulatorRunner
 from utils import (
     add_drake_resource_path,
     build_simple_car_simulator,
+    launch_bridge,
     launch_visualizer
 )
 
@@ -90,6 +91,7 @@ def main():
     runner = SimulatorRunner(simulator, 0.001, start_paused)
 
     try:
+        launch_bridge(launcher)
         launch_visualizer(launcher, "layoutWithTeleop.config")
         runner.Start()
         launcher.wait(float("Inf"))


### PR DESCRIPTION
An issue was reported [here](https://github.com/ToyotaResearchInstitute/delphyne-gui/pull/44#issuecomment-362288352). This should fix it.