### PR TITLE
Add in sleeps to the LCM channel repeater tests.

### DIFF
--- a/bridge/test/lcm_channel_repeater_test.cc
+++ b/bridge/test/lcm_channel_repeater_test.cc
@@ -118,6 +118,8 @@ GTEST_TEST(LCMChannelRepeaterTest, TestEndToEndEcho) {
   // Consume LCM message
   lcm->handleTimeout(500);
 
+  sleep(1.0);
+
   // Check handler has been called
   ASSERT_TRUE(handler1Called);
 }
@@ -149,6 +151,8 @@ GTEST_TEST(LCMChannelRepeaterTest, TestHandlerNotCalled) {
 
   // Consume LCM message
   lcm->handleTimeout(500);
+
+  sleep(1.0);
 
   // Check handler has not been called
   ASSERT_FALSE(handler1Called);
@@ -201,6 +205,8 @@ GTEST_TEST(LCMChannelRepeaterTest, TestMultipleChannels) {
   // Consume LCM messages
   lcm->handleTimeout(500);
   lcm->handleTimeout(500);
+
+  sleep(1.0);
 
   // Check handlers have been called
   ASSERT_TRUE(handler1Called);


### PR DESCRIPTION
With the new threading structure in ign-transport, it can
sometimes be the case that the test for whether the handler
was properly called can happen before the handler actually
gets called, leading to test failures.  While I don't generally
like adding sleeps, this code should go away soon, so I don't
want to spend a lot of time making something more correct.
This seems to workaround the problem for me.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>