### PR TITLE
Install the drake dependencies from the version of drake we are using.

### DIFF
--- a/scripts/continuous_integration/jenkins/build_workspace
+++ b/scripts/continuous_integration/jenkins/build_workspace
@@ -29,7 +29,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set -euo pipefail
+set -eu
 
 # We want to build up a workspace similar to the one that is recommended at
 # https://github.com/ToyotaResearchInstitute/delphyne-gui/blob/master/README.md
@@ -111,3 +111,7 @@ popd # workspace
 # since vcs will not have the proper credentials to access them.
 sed -e '/^ *delphyne/d' workspace/delphyne_gui/delphyne.repos > deps.repos
 vcs import workspace < deps.repos
+
+# Install the drake dependencies.  Ideally this would have been done in 'setup',
+# but we didn't yet have the script there so we do it here.
+yes | sudo ./workspace/drake/setup/ubuntu/16.04/install_prereqs.sh

--- a/scripts/continuous_integration/jenkins/setup
+++ b/scripts/continuous_integration/jenkins/setup
@@ -29,7 +29,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set -eu
+set -euo pipefail
 
 # Here we install all of the dependencies necessary to build delphyne.  This
 # includes the direct dependencies (as called out in
@@ -78,8 +78,6 @@ uuid-dev
 EOF
 )
 
-# Install the drake dependencies.
-wget https://raw.githubusercontent.com/RobotLocomotion/drake/master/setup/ubuntu/16.04/install_prereqs_binary_distribution.sh
-wget https://raw.githubusercontent.com/RobotLocomotion/drake/master/setup/ubuntu/16.04/install_prereqs.sh
-chmod +x install_prereqs.sh
-yes | sudo ./install_prereqs.sh
+# In theory we would install the drake dependencies here as well, but we don't
+# really know them until we pull the delphyne.repos file from delphyne-gui.
+# Thus we delay that installation until the 'build_workspace' step.


### PR DESCRIPTION
That is, don't always pull master.  This forces us to break
up our pipeline slightly awkwardly, but it is the correct
thing to do.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>