### PR TITLE
New ign to lcm

### DIFF
--- a/backend/ign_to_lcm_translation.cc
+++ b/backend/ign_to_lcm_translation.cc
@@ -28,11 +28,12 @@
 
 #include <chrono>
 #include <cstdint>
+#include <vector>
 
 #include "backend/ign_to_lcm_translation.h"
 #include "drake/lcmt_driving_command_t.hpp"
-#include <drake/lcmt_viewer_draw.hpp>
-#include <ignition/msgs.hh>
+#include "drake/lcmt_viewer_draw.hpp"
+#include "ignition/msgs.hh"
 #include "protobuf/automotive_driving_command.pb.h"
 
 #include "backend/system.h"
@@ -55,43 +56,45 @@ std::vector<float> ignToVector(const ignition::msgs::Quaternion& orientation) {
       static_cast<float>(orientation.y()), static_cast<float>(orientation.z())};
 }
 
-void ignToLcm(const ignition::msgs::AutomotiveDrivingCommand& ignDrivingCommand,
-              drake::lcmt_driving_command_t* lcmDrivingCommand) {
-  if (ignDrivingCommand.has_time()) {
-    lcmDrivingCommand->timestamp =
-        millisFromSecs(ignDrivingCommand.time().sec()) +
-        millisFromNsecs(ignDrivingCommand.time().nsec());
+void ignToLcm(
+    const ignition::msgs::AutomotiveDrivingCommand& ign_driving_command,
+    drake::lcmt_driving_command_t* lcm_driving_command) {
+  if (ign_driving_command.has_time()) {
+    lcm_driving_command->timestamp =
+        millisFromSecs(ign_driving_command.time().sec()) +
+        millisFromNsecs(ign_driving_command.time().nsec());
   } else {
     int64_t milliseconds = std::chrono::system_clock::now().time_since_epoch() /
                            std::chrono::milliseconds(1);
-    lcmDrivingCommand->timestamp = milliseconds;
+    lcm_driving_command->timestamp = milliseconds;
   }
-  lcmDrivingCommand->steering_angle = ignDrivingCommand.theta();
-  lcmDrivingCommand->acceleration = ignDrivingCommand.acceleration();
+  lcm_driving_command->steering_angle = ign_driving_command.theta();
+  lcm_driving_command->acceleration = ign_driving_command.acceleration();
 }
 
-void ignToLcm(const ignition::msgs::Model_V& robotModels,
-              drake::lcmt_viewer_draw* robotDrawData) {
-  robotDrawData->timestamp =
-      millisFromSecs(robotModels.header().stamp().sec()) +
-      millisFromNsecs(robotModels.header().stamp().nsec());
+void ignToLcm(const ignition::msgs::Model_V& robot_models,
+              drake::lcmt_viewer_draw* robot_draw_data) {
+  robot_draw_data->timestamp =
+      millisFromSecs(robot_models.header().stamp().sec()) +
+      millisFromNsecs(robot_models.header().stamp().nsec());
 
   // Each ignition model has many links using the same id, but this is
   // flattened in LCM
-  robotDrawData->num_links = 0;
-  for (int i = 0; i < robotModels.models_size(); ++i) {
-    auto robotModel = robotModels.models(i);
+  robot_draw_data->num_links = 0;
+  for (int i = 0; i < robot_models.models_size(); ++i) {
+    const ::ignition::msgs::Model& robot_model = robot_models.models(i);
 
-    for (int j = 0; j < robotModel.link_size(); ++j) {
-      robotDrawData->num_links += 1;
-      auto link = robotModel.link(j);
-      auto pose = link.pose();
+    for (int j = 0; j < robot_model.link_size(); ++j) {
+      const ::ignition::msgs::Link& link = robot_model.link(j);
+      const ::ignition::msgs::Pose& pose = link.pose();
 
-      robotDrawData->robot_num.push_back(robotModel.id());
-      robotDrawData->link_name.push_back(link.name());
+      robot_draw_data->robot_num.push_back(robot_model.id());
+      robot_draw_data->link_name.push_back(link.name());
 
-      robotDrawData->position.push_back(ignToVector(pose.position()));
-      robotDrawData->quaternion.push_back(ignToVector(pose.orientation()));
+      robot_draw_data->position.push_back(ignToVector(pose.position()));
+      robot_draw_data->quaternion.push_back(ignToVector(pose.orientation()));
+
+      robot_draw_data->num_links += 1;
     }
   }
 }

--- a/backend/ign_to_lcm_translation.h
+++ b/backend/ign_to_lcm_translation.h
@@ -44,17 +44,18 @@ namespace delphyne {
 namespace backend {
 
 /// \brief Translate a driving command from LCM to ignition
-/// \param[in]  ignDrivingCommand An ignition message containing the driving
+/// \param[in]  ign_driving_command An ignition message containing the driving
 /// command
-/// \param[out] lcmDrivingCommand The resulting LCM command
-void ignToLcm(const ignition::msgs::AutomotiveDrivingCommand& ignDrivingCommand,
-              drake::lcmt_driving_command_t* lcmDrivingCommand);
+/// \param[out] lcm_driving_command The resulting LCM command
+void ignToLcm(
+    const ignition::msgs::AutomotiveDrivingCommand& ign_driving_command,
+    drake::lcmt_driving_command_t* lcm_driving_command);
 
 /// \brief Translate a model vector ignition message to an LCM view draw message
-/// \param[in]  robotModels An ignition message containing the model vector
-/// \param[out] robotDrawData The resulting LCM view draw message
-void ignToLcm(const ignition::msgs::Model_V& robotModels,
-              drake::lcmt_viewer_draw* robotDrawData);
+/// \param[in]  robot_models An ignition message containing the model vector
+/// \param[out] robot_draw_data The resulting LCM view draw message
+void ignToLcm(const ignition::msgs::Model_V& robot_models,
+              drake::lcmt_viewer_draw* robot_draw_data);
 
 }  // namespace backend
 }  // namespace delphyne

--- a/backend/test/ign_to_lcm_translation_test.cc
+++ b/backend/test/ign_to_lcm_translation_test.cc
@@ -26,196 +26,122 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <iostream>
-#include <gtest/gtest.h>
-#include <ignition/msgs.hh>
-
 #include "backend/ign_to_lcm_translation.h"
+
+#include <iostream>
+
+#include "backend/test/helpers.h"
 #include "drake/lcmt_driving_command_t.hpp"
-#include <drake/lcmt_viewer_draw.hpp>
-#include <ignition/msgs.hh>
+#include "drake/lcmt_viewer_draw.hpp"
+#include "gtest/gtest.h"
+#include "ignition/msgs.hh"
 #include "protobuf/automotive_driving_command.pb.h"
 
 namespace delphyne {
 namespace backend {
 
-//////////////////////////////////////////////////
-/// \brief Test that the ignition AutomotiveDrivingCommand
-/// message is properly translated to its LCM counterpart
+/////////////////////////////////////////////////
+// \brief Test that the ignition AutomotiveDrivingCommand
+// message is properly translated to its LCM counterpart
 GTEST_TEST(ignToLcm, TestAutomotiveDrivingCommandTranslation) {
-  // Define the ignition command
-  ignition::msgs::AutomotiveDrivingCommand ignDrivingMsg;
-  // Define LCM expected message
-  drake::lcmt_driving_command_t lcmDrivingMsg;
-  // Fill LCM data
-  ignDrivingMsg.mutable_time()->set_sec(123);
-  ignDrivingMsg.mutable_time()->set_nsec(987222111);
-  ignDrivingMsg.set_theta(0.12);
-  ignDrivingMsg.set_acceleration(15.7);
+  // Defines the ignition command
+  ignition::msgs::AutomotiveDrivingCommand ign_driving_message;
+  // Defines LCM expected message
+  drake::lcmt_driving_command_t lcm_driving_message;
+  // Fills LCM data
+  ign_driving_message.mutable_time()->set_sec(123);
+  ign_driving_message.mutable_time()->set_nsec(987222111);
+  ign_driving_message.set_theta(0.12);
+  ign_driving_message.set_acceleration(15.7);
 
-  // Translate from ignition to LCM
-  ignToLcm(ignDrivingMsg, &lcmDrivingMsg);
+  // Translates from ignition to LCM
+  ignToLcm(ign_driving_message, &lcm_driving_message);
 
-  // Verify generated LCM message
-  EXPECT_EQ(123987, lcmDrivingMsg.timestamp);
-  EXPECT_EQ(0.12, lcmDrivingMsg.steering_angle);
-  EXPECT_EQ(15.7, lcmDrivingMsg.acceleration);
+  // Verifies generated LCM message
+  EXPECT_EQ(123987, lcm_driving_message.timestamp);
+  EXPECT_EQ(0.12, lcm_driving_message.steering_angle);
+  EXPECT_EQ(15.7, lcm_driving_message.acceleration);
 }
 
-//////////////////////////////////////////////////
-/// \brief Test that the ignition AutomotiveDrivingCommand
-/// message is properly translated to its LCM counterpart
+/////////////////////////////////////////////////
+// \brief Test that the ignition AutomotiveDrivingCommand
+// message is properly translated to its LCM counterpart
 GTEST_TEST(ignToLcm, TestAutomotiveDrivingCommandTranslationDefaultValues) {
-  // Define the ignition command
-  ignition::msgs::AutomotiveDrivingCommand ignDrivingMsg;
-  // Define LCM expected message
-  drake::lcmt_driving_command_t lcmDrivingMsg;
+  // Defines the ignition command
+  ignition::msgs::AutomotiveDrivingCommand ign_driving_message;
+  // Defines LCM expected message
+  drake::lcmt_driving_command_t lcm_driving_message;
 
-  // Translate from ignition to LCM
-  ignToLcm(ignDrivingMsg, &lcmDrivingMsg);
+  // Translates from ignition to LCM
+  ignToLcm(ign_driving_message, &lcm_driving_message);
 
-  // Verify generated LCM message
-  EXPECT_EQ(lcmDrivingMsg.steering_angle, 0);
-  EXPECT_EQ(lcmDrivingMsg.acceleration, 0);
+  // Verifies generated LCM message
+  EXPECT_EQ(lcm_driving_message.steering_angle, 0);
+  EXPECT_EQ(lcm_driving_message.acceleration, 0);
 }
 
-//////////////////////////////////////////////////
-/// \brief Test that the ignition Robot Model message is properly
-/// translated to its LCM counterpart
+/////////////////////////////////////////////////
+// \brief Test that the ignition Robot Model message is properly
+// translated to its LCM counterpart
 GTEST_TEST(ignToLcm, TestRobotModelTranslation) {
-  ignition::msgs::Model_V robotModels;
+  ignition::msgs::Model_V robot_models;
 
-  robotModels.mutable_header()->mutable_stamp()->set_sec(123);
-  robotModels.mutable_header()->mutable_stamp()->set_nsec(456000000);
+  robot_models.mutable_header()->mutable_stamp()->set_sec(123);
+  robot_models.mutable_header()->mutable_stamp()->set_nsec(456000000);
 
   for (int i = 0; i < 3; ++i) {
-    auto model = robotModels.add_models();
+    ::ignition::msgs::Model* model = robot_models.add_models();
     model->set_id(i);
 
     for (int j = 0; j < 2; ++j) {
-      auto link = model->add_link();
+      ::ignition::msgs::Link* link = model->add_link();
 
-      auto pose = link->mutable_pose();
-      auto position = pose->mutable_position();
-      auto orientation = pose->mutable_orientation();
+      ::ignition::msgs::Pose* pose = link->mutable_pose();
+      ignition::msgs::Vector3d* position = pose->mutable_position();
+      ignition::msgs::Quaternion* orientation = pose->mutable_orientation();
 
       link->set_name(std::to_string(i) + std::to_string(j));
 
       position->set_x(i);
-      position->set_y(j + 5);
-      position->set_z(i + 10);
+      position->set_y(j + 5.0);
+      position->set_z(i + 10.0);
 
       orientation->set_w(i);
-      orientation->set_x(j + 5);
-      orientation->set_y(i + 10);
-      orientation->set_z(j + 15);
+      orientation->set_x(j + 5.0);
+      orientation->set_y(i + 10.0);
+      orientation->set_z(j + 15.0);
     }
   }
 
-  drake::lcmt_viewer_draw robotDrawData;
-  ignToLcm(robotModels, &robotDrawData);
+  drake::lcmt_viewer_draw robot_draw_data;
+  ignToLcm(robot_models, &robot_draw_data);
 
-  EXPECT_EQ(robotDrawData.timestamp, 123456);
+  EXPECT_EQ(robot_draw_data.timestamp, 123456);
 
-  EXPECT_EQ(robotDrawData.num_links, 6);
-  EXPECT_EQ(robotDrawData.robot_num.size(), 6);
-  EXPECT_EQ(robotDrawData.link_name.size(), 6);
-  EXPECT_EQ(robotDrawData.position.size(), 6);
-  EXPECT_EQ(robotDrawData.quaternion.size(), 6);
+  EXPECT_EQ(robot_draw_data.num_links, 6);
+  EXPECT_EQ(robot_draw_data.robot_num.size(), 6);
+  EXPECT_EQ(robot_draw_data.link_name.size(), 6);
+  EXPECT_EQ(robot_draw_data.position.size(), 6);
+  EXPECT_EQ(robot_draw_data.quaternion.size(), 6);
 
-  // Model 0 link 0
-  EXPECT_EQ(robotDrawData.robot_num[0], 0);
-  EXPECT_EQ(robotDrawData.link_name[0], "00");
-
-  EXPECT_EQ(robotDrawData.position[0][0], 0);
-  EXPECT_EQ(robotDrawData.position[0][1], 5);
-  EXPECT_EQ(robotDrawData.position[0][2], 10);
-
-  EXPECT_EQ(robotDrawData.quaternion[0][0], 0);
-  EXPECT_EQ(robotDrawData.quaternion[0][1], 5);
-  EXPECT_EQ(robotDrawData.quaternion[0][2], 10);
-  EXPECT_EQ(robotDrawData.quaternion[0][3], 15);
-
-  // Model 0 link 1
-  EXPECT_EQ(robotDrawData.robot_num[1], 0);
-  EXPECT_EQ(robotDrawData.link_name[1], "01");
-
-  EXPECT_EQ(robotDrawData.position[1][0], 0);
-  EXPECT_EQ(robotDrawData.position[1][1], 6);
-  EXPECT_EQ(robotDrawData.position[1][2], 10);
-
-  EXPECT_EQ(robotDrawData.quaternion[1][0], 0);
-  EXPECT_EQ(robotDrawData.quaternion[1][1], 6);
-  EXPECT_EQ(robotDrawData.quaternion[1][2], 10);
-  EXPECT_EQ(robotDrawData.quaternion[1][3], 16);
-
-  // Model 1 link 0
-  EXPECT_EQ(robotDrawData.robot_num[2], 1);
-  EXPECT_EQ(robotDrawData.link_name[2], "10");
-
-  EXPECT_EQ(robotDrawData.position[2][0], 1);
-  EXPECT_EQ(robotDrawData.position[2][1], 5);
-  EXPECT_EQ(robotDrawData.position[2][2], 11);
-
-  EXPECT_EQ(robotDrawData.quaternion[2][0], 1);
-  EXPECT_EQ(robotDrawData.quaternion[2][1], 5);
-  EXPECT_EQ(robotDrawData.quaternion[2][2], 11);
-  EXPECT_EQ(robotDrawData.quaternion[2][3], 15);
-
-  // Model 1 link 1
-  EXPECT_EQ(robotDrawData.robot_num[3], 1);
-  EXPECT_EQ(robotDrawData.link_name[3], "11");
-
-  EXPECT_EQ(robotDrawData.position[3][0], 1);
-  EXPECT_EQ(robotDrawData.position[3][1], 6);
-  EXPECT_EQ(robotDrawData.position[3][2], 11);
-
-  EXPECT_EQ(robotDrawData.quaternion[3][0], 1);
-  EXPECT_EQ(robotDrawData.quaternion[3][1], 6);
-  EXPECT_EQ(robotDrawData.quaternion[3][2], 11);
-  EXPECT_EQ(robotDrawData.quaternion[3][3], 16);
-
-  // Model 2 link 0
-  EXPECT_EQ(robotDrawData.robot_num[4], 2);
-  EXPECT_EQ(robotDrawData.link_name[4], "20");
-
-  EXPECT_EQ(robotDrawData.position[4][0], 2);
-  EXPECT_EQ(robotDrawData.position[4][1], 5);
-  EXPECT_EQ(robotDrawData.position[4][2], 12);
-
-  EXPECT_EQ(robotDrawData.quaternion[4][0], 2);
-  EXPECT_EQ(robotDrawData.quaternion[4][1], 5);
-  EXPECT_EQ(robotDrawData.quaternion[4][2], 12);
-  EXPECT_EQ(robotDrawData.quaternion[4][3], 15);
-
-  // Model 2 link 1
-  EXPECT_EQ(robotDrawData.robot_num[5], 2);
-  EXPECT_EQ(robotDrawData.link_name[5], "21");
-
-  EXPECT_EQ(robotDrawData.position[5][0], 2);
-  EXPECT_EQ(robotDrawData.position[5][1], 6);
-  EXPECT_EQ(robotDrawData.position[5][2], 12);
-
-  EXPECT_EQ(robotDrawData.quaternion[5][0], 2);
-  EXPECT_EQ(robotDrawData.quaternion[5][1], 6);
-  EXPECT_EQ(robotDrawData.quaternion[5][2], 12);
-  EXPECT_EQ(robotDrawData.quaternion[5][3], 16);
+  EXPECT_TRUE(
+      delphyne::test::CheckMsgTranslation(robot_draw_data, robot_models));
 }
 
-//////////////////////////////////////////////////
-/// \brief Test that the ignition Robot Model message is properly
-/// translated to its LCM counterpart
+/////////////////////////////////////////////////
+// \brief Test that the ignition Robot Model message is properly
+// translated to its LCM counterpart
 GTEST_TEST(ignToLcm, TestRobotModelTranslationDefaultValues) {
-  ignition::msgs::Model_V robotModels;
-  drake::lcmt_viewer_draw robotDrawData;
+  ignition::msgs::Model_V robot_models;
+  drake::lcmt_viewer_draw robot_draw_data;
 
-  ignToLcm(robotModels, &robotDrawData);
+  ignToLcm(robot_models, &robot_draw_data);
 
-  EXPECT_EQ(robotDrawData.num_links, 0);
-  EXPECT_EQ(robotDrawData.robot_num.size(), 0);
-  EXPECT_EQ(robotDrawData.link_name.size(), 0);
-  EXPECT_EQ(robotDrawData.position.size(), 0);
-  EXPECT_EQ(robotDrawData.quaternion.size(), 0);
+  EXPECT_EQ(robot_draw_data.num_links, 0);
+  EXPECT_EQ(robot_draw_data.robot_num.size(), 0);
+  EXPECT_EQ(robot_draw_data.link_name.size(), 0);
+  EXPECT_EQ(robot_draw_data.position.size(), 0);
+  EXPECT_EQ(robot_draw_data.quaternion.size(), 0);
 }
 
 }  // namespace backend


### PR DESCRIPTION
Added a translation from `ignition::msgs::Model_V` to `drake::lcmt_viewer_draw` (which is as of now unused), along with unit tests.

This closes #233