### PR TITLE
Refactored keyboard_controlled_simulation.py

### DIFF
--- a/backend/automotive_simulator.cc
+++ b/backend/automotive_simulator.cc
@@ -749,6 +749,12 @@ double AutomotiveSimulator<T>::GetRealtimeRate() const {
   return simulator_->get_target_realtime_rate();
 }
 
+template <typename T>
+void AutomotiveSimulator<T>::ResetStatistics() {
+  DELPHYNE_DEMAND(has_started());
+  simulator_->ResetStatistics();
+}
+
 template class AutomotiveSimulator<double>;
 
 }  // namespace backend

--- a/backend/automotive_simulator.h
+++ b/backend/automotive_simulator.h
@@ -342,6 +342,11 @@ class AutomotiveSimulator {
   /// @pre Start() has been called.
   double GetRealtimeRate() const;
 
+  /// @see documentation of Simulator::ResetStatistics.
+  ///
+  /// @pre Start() has been called.
+  void ResetStatistics();
+
  private:
   int allocate_vehicle_number();
 

--- a/backend/simulation_runner.h
+++ b/backend/simulation_runner.h
@@ -1,3 +1,4 @@
+
 // Copyright 2017 Open Source Robotics Foundation
 //
 // Redistribution and use in source and binary forms, with or without
@@ -215,6 +216,21 @@ class SimulatorRunner {
 
   /// See documentation of AutomotiveSimulator::GetRealtimeRate.
   double GetRealtimeRate() const { return simulator_->GetRealtimeRate(); }
+
+  /// @brief Returns the paused state of the simulation.
+  bool IsPaused() const;
+
+  /// @brief Requests the simulation to execute a single simulation step.
+  /// The simulation must be paused before calling this method.
+  /// @pre Start() has been called.
+  /// @pre Paused() has been called.
+  void RequestStep(double time_step);
+
+  ///  @brief Pauses the simulation, no-op if called multiple times.
+  void Pause();
+
+  ///  @brief Unauses the simulation, no-op if called multiple times.
+  void Unpause();
 
  private:
   // @brief Process one RobotModelRequest message.

--- a/backend/simulation_runner_py.cc
+++ b/backend/simulation_runner_py.cc
@@ -66,7 +66,11 @@ PYBIND11_MODULE(simulation_runner_py, m) {
       .def("Start", &SimulatorRunner::Start)
       .def("Stop", &SimulatorRunner::Stop)
       .def("AddStepCallback", &SimulatorRunner::AddStepCallback)
-      .def("RunSimulationStep", &SimulatorRunner::RunSimulationStep);
+      .def("RunSimulationStep", &SimulatorRunner::RunSimulationStep)
+      .def("IsPaused", &SimulatorRunner::IsPaused)
+      .def("Pause", &SimulatorRunner::Pause)
+      .def("RequestStep", &SimulatorRunner::RequestStep)
+      .def("Unpause", &SimulatorRunner::Unpause);
   py::class_<AutomotiveSimulator<double>>(m, "AutomotiveSimulator")
       .def(py::init(
           [](void) { return std::make_unique<AutomotiveSimulator<double>>(); }))

--- a/backend/test/simulation_runner_test.cc
+++ b/backend/test/simulation_runner_test.cc
@@ -76,7 +76,7 @@ class SimulationRunnerTest : public ::testing::Test {
   ignition::transport::Node node_;
 };
 
-// \brief Checks that WaitForShutdown captures the SIGINT signal and the
+// @brief Checks that WaitForShutdown captures the SIGINT signal and the
 // simulation terminates gracefully.
 TEST_F(SimulationRunnerTest, SigIntTermination) {
   sim_runner_->Start();
@@ -92,7 +92,7 @@ TEST_F(SimulationRunnerTest, SigIntTermination) {
   if (t.joinable()) t.join();
 }
 
-// \brief Checks the time elapsed during the simulation
+// @brief Checks the time elapsed during the simulation
 // step was at least as much as the defined kTimeStep.
 TEST_F(SimulationRunnerTest, ElapsedTimeOnStep) {
   // Need to run a first step for the counters that handle real-time rate
@@ -117,7 +117,7 @@ TEST_F(SimulationRunnerTest, ElapsedTimeOnStep) {
   EXPECT_LE(duration, max_simulation_time);
 }
 
-// \brief Verifies that an incoming message has
+// @brief Asserts that an incoming message has
 // been consumed from the incoming_msgs_ queue
 TEST_F(SimulationRunnerTest, ConsumedEventOnQueue) {
   const std::string service_name{"test_service_name"};
@@ -140,6 +140,80 @@ TEST_F(SimulationRunnerTest, ConsumedEventOnQueue) {
   sim_runner_->RunSimulationStep();
 
   EXPECT_TRUE(callback_called_);
+}
+
+// @brief Asserts that an incoming message is consumed
+// from the queue even if the simulation is paused.
+TEST_F(SimulationRunnerTest, ConsumedEventOnQueueWhenPaused) {
+  sim_runner_->Start();
+  sim_runner_->Pause();
+
+  const std::string service_name{"test_service_name"};
+
+  ignition::msgs::RobotModelRequest robot_model_request_msg;
+
+  robot_model_request_msg.set_response_topic(service_name);
+
+  AdvertiseRobotModelRequest(service_name);
+
+  ignition::msgs::Boolean response;
+  const unsigned int timeout = 100;
+  bool result = false;
+  const std::string service = "/get_robot_model";
+  node_.Request(service, robot_model_request_msg, timeout, response, result);
+  EXPECT_TRUE(result);
+
+  // Wait until the currently running step of the loop finishes.
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+  EXPECT_TRUE(callback_called_);
+}
+
+// @brief Asserts that the Pause method
+// pauses the advance of the simulation.
+TEST_F(SimulationRunnerTest, TestPauseSetMethod) {
+  sim_runner_->Start();
+
+  EXPECT_FALSE(sim_runner_->IsPaused());
+
+  sim_runner_->Pause();
+
+  EXPECT_TRUE(sim_runner_->IsPaused());
+}
+
+// @brief Asserts that the Unpause method lets the
+// simulator run again if it was previously paused.
+TEST_F(SimulationRunnerTest, TestPauseResetMethod) {
+  sim_runner_->Start();
+  sim_runner_->Pause();
+
+  EXPECT_TRUE(sim_runner_->IsPaused());
+
+  sim_runner_->Unpause();
+
+  EXPECT_FALSE(sim_runner_->IsPaused());
+
+  // Calling the Unpause method when the simulation
+  // is already unpaused leads to a no-op.
+  sim_runner_->Unpause();
+
+  EXPECT_FALSE(sim_runner_->IsPaused());
+}
+
+// @brief Asserts that the execution breaks if a RequestStep
+// is received if the simulation hasn't started.
+TEST_F(SimulationRunnerTest, TestRequestStepWhenNotStarted) {
+  EXPECT_DEATH(sim_runner_->RequestStep(0.01), "condition 'enabled_' failed.");
+}
+
+// @brief Asserts that the execution breaks if a RequestStep
+// is received if the simulation is paused.
+TEST_F(SimulationRunnerTest, TestRequestStepWhenUnPaused) {
+  sim_runner_->Start();
+
+  EXPECT_FALSE(sim_runner_->IsPaused());
+
+  EXPECT_DEATH(sim_runner_->RequestStep(0.1), "condition 'paused_' failed.");
 }
 
 }  // namespace backend

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -10,4 +10,4 @@ make -j$( getconf _NPROCESSORS_ONLN )
 make test
 
 printf "\nRunning Python tests:\n"
-python -m unittest discover backend "*_test.py"
+python -m unittest discover backend/test "*_test.py"


### PR DESCRIPTION
Fixes #240 
- Adds methods to control the advance of the simulation from the `SimulatorRunner`'s public interface.
    - Added the python bindings for them.
- Refactor `keyboard_controlled_simulation.py` to make use of the new control methods described above.
- Adds a workaround for the erratic behavior after un-pausing the simulation reported on [this issue](https://github.com/RobotLocomotion/drake/issues/8090) in drake.
- Re-enable python callbacks when the simulation is paused, updated python test accordingly.
- Fixes the `run_tests.sh` script