### PR TITLE
Add constructor to SimulatorRunner's list of python bindings

### DIFF
--- a/backend/python_examples/realtime_rate_changer.py
+++ b/backend/python_examples/realtime_rate_changer.py
@@ -122,7 +122,7 @@ def main():
 
     simulator = build_simple_car_simulator()
 
-    runner = SimulatorRunner(simulator, 0.001, initial_realtime_rate, False)
+    runner = SimulatorRunner(simulator, 0.001, initial_realtime_rate)
 
     rate_changer = RealtimeRateChanger(runner, initial_steps)
 

--- a/backend/simulation_runner_py.cc
+++ b/backend/simulation_runner_py.cc
@@ -54,11 +54,8 @@ namespace {
 PYBIND11_MODULE(simulation_runner_py, m) {
   py::class_<SimulatorRunner>(m, "SimulatorRunner")
       .def(py::init<unique_ptr<AutomotiveSimulator<double>>, double>())
-      // TODO(basicNew): Add the missing
-      // `unique_ptr<AutomotiveSimulator<double>>, double, double>()`
-      // constructor. Note that this means overloading by type, which I think
-      // will need a custom python constructor.
       .def(py::init<unique_ptr<AutomotiveSimulator<double>>, double, bool>())
+      .def(py::init<unique_ptr<AutomotiveSimulator<double>>, double, double>())
       .def(py::init<unique_ptr<AutomotiveSimulator<double>>, double, double,
                     bool>())
       .def("SetRealtimeRate", &SimulatorRunner::SetRealtimeRate)


### PR DESCRIPTION
Fixes #256 
- Adds the missing SimulatorRunner's constructor with arguments of type `<AutomotiveSimulator<double>>, double, double>` by making use of the fix pushed [here](https://github.com/RobotLocomotion/pybind11/pull/11).

This PR goes hand-in-hand with [ToyotaResearchInstitute/delphyne-gui#60](https://github.com/ToyotaResearchInstitute/delphyne-gui/pull/60).