### PR TITLE
Fixed run_tests.sh

### DIFF
--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -18,5 +18,9 @@ cmake $DELPHYNE_SOURCE_DIR -DCMAKE_INSTALL_PREFIX=../../install
 make -j$( getconf _NPROCESSORS_ONLN )
 make test
 
-printf "\nRunning Python tests:\n"
-python -m unittest discover backend/test "*_test.py"
+printf "\nRunning python tests:\n"
+# Note that python tests also run from the $DELPHYNE_WS_DIR/build/delphyne dir.
+# Do not attempt to run them directly from sources, they'll fail because they
+# need to find the pybind11-generated libraries.
+# TODO(apojomovsky): replace this by `python setup.py test` after #290 is set up.
+python -m unittest discover backend "*_test.py"


### PR DESCRIPTION
Fixes #284 
There was an issue in the python unittests PATH in the script, it was : `backend/test` where it should be only `backend/`.
Also adds some checks and comments to make the script a bit more verbose.