### PR TITLE
Add monolane loading

### DIFF
--- a/backend/python/examples/README.md
+++ b/backend/python/examples/README.md
@@ -6,3 +6,127 @@ simulation runner.
 For all the examples below it's assumed that the Delphyne backend was successfully
 built with CMake, as shown in the instructions
 [here](https://github.com/ToyotaResearchInstitute/delphyne-gui/blob/master/README.md).
+<h1 id="road_loading">road_loading</h1>
+
+
+This example shows how to run a simulation that includes a road. For the
+time being three road examples are supported: dragway, onramp and monolane.
+This demo uses the subcommand style, where each road type can handle different
+parameters (to list the available arguments just do
+`$ road_loading_example <road_type> -h`). Below are some examples of usage:
+
+
+A dragway that is 200 meters long and has a side-shoulder of 2.5 meters:
+
+```
+$ road_loading_example.py dragway --length=200 --shoulder-width=2.5
+```
+
+An on-ramp road:
+
+```
+$ road_loading_example.py onramp
+```
+
+Load an arbitrary monolane file:
+
+```
+$ road_loading_example.py monolane
+--filename='./install/share/delphyne/road_samples/double_ring.yaml'
+```
+
+
+<h1 id="realtime_rate_changer">realtime_rate_changer</h1>
+
+
+This example shows how the real-time simulation rate can be set both when the
+simulator runner is created and while the simulation is running.
+
+To pass an initial real-time rate use the `--realtime_rate` flag, like:
+
+```
+$ realtime_rate_changer.py --realtime_rate=2.0
+```
+
+If none is specified the default will be set to `1.0` (i.e. run the simulation
+in real-time).
+
+Once the scripts starts running it will cycle between a real-time rate of `0.6`
+to `1.6` to depict how dynamic real-time rate impacts on the simulation.
+
+<h1 id="keyboard_controlled_simulation">keyboard_controlled_simulation</h1>
+
+
+This example shows how to use the keyboard events to control the advance of
+a simulation. The simulation will open the usual simple car in the center of
+the scene, which can be driven using the keyboard on the GUI's teleop widget.
+However, by switching to the console, we can `play`/`pause`/`step`/`quit` the
+simulation.
+
+```
+$ cd <delphyne_ws>/install/bin
+$ ./keyboard_controlled_simulation.py
+```
+
+ The supported keys for the demo:
+
+<`p`> will pause the simulation if running and vice-versa.
+
+<`s`> will step the simulation once if paused.
+
+<`q`> will stop the simulation and quit the demo.
+
+<h1 id="simple_python_binding">simple_python_binding</h1>
+
+This is a minimal example of starting an automotive simulation using a
+python binding to the C++ `SimulatorRunner` class.
+
+Note that this is not a configurable demo, it will just create a sample
+simulation with a prius car that can be driven around.
+
+Check the other examples in this directory for more advanced uses.
+
+<h1 id="start_simulation_paused">start_simulation_paused</h1>
+
+
+This example show how to use the `SimulationRunner`'s (optional) third
+constructor argument to start in pause mode.
+
+```
+$ cd <delphyne_ws>/install/bin
+$ ./start_simulation_paused.py
+```
+
+This command will spawn a visualizer instance and start the simulation in
+paused mode.
+
+ ## Unpausing the simulation
+
+- The most user-friendly way of unpausing the simulation is by using the
+`TimePanel` widget in the visualizer. This panel allows to control the
+simulation with `Play` / `Pause` / `Step` buttons from the GUI.
+
+- Through the command line, by using the `WorldControl` service, publishing a
+message with the right content into the `/world_control` channel:
+
+```
+$ cd <delphyne_ws>/install/bin
+$ ./ign service --service /world_control --reqtype ignition.msgs.WorldControl --reptype ignition.msgs.Boolean --timeout 500 --req 'pause: false'
+```
+
+
+<h1 id="time_bounded_simulation">time_bounded_simulation</h1>
+
+
+This example shows how to run a simulation for a fixed period of time (15
+seconds by default). As an added bonus, the user can also specify the real-time
+simulation rate (which by default is 1.0).
+
+The following command depicts how to run a simulation for 30 sim seconds using
+a real-time rate of 2x (so it should run in approximately 15 wall clock
+seconds):
+
+```
+$ time_bounded_simulation.py --realtime_rate=2.0 --duration=30.0
+```
+

--- a/backend/python/examples/road_loading.py
+++ b/backend/python/examples/road_loading.py
@@ -36,13 +36,14 @@ $ road_loading_example.py monolane
 from __future__ import print_function
 
 import argparse
+import sys
 
 from python_bindings import (
+    AutomotiveSimulator,
     RoadBuilder,
-    SimulatorRunner,
-    AutomotiveSimulator
+    SimulatorRunner
 )
-from simulation_utils import launch_visualizer
+from simulation_utils import launch_interactive_simulation
 
 SIMULATION_TIME_STEP = 0.001
 
@@ -52,7 +53,9 @@ def main():
     road to be added from the command line args"""
 
     parser = argparse.ArgumentParser(
-        prog="roads",
+        prog="road_loading",
+        description="Simple demo that shows how to load a road network in a \
+        simulation by using the RoadBuilder class.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     subparsers = parser.add_subparsers(dest="road_type")
 
@@ -60,21 +63,21 @@ def main():
     dragway_parser = subparsers.add_parser("dragway")
     dragway_parser.add_argument("--lanes", default=3,
                                 type=int,
-                                help="The number of lanes the dragway has")
+                                help="the number of lanes the dragway has")
     dragway_parser.add_argument("--length", default=100.0,
                                 type=float,
-                                help="The length of the dragway, in meters")
+                                help="the length of the dragway, in meters")
     dragway_parser.add_argument("--lane-width", default=3.7,
                                 type=float,
-                                help="The width of each lane, in meters")
+                                help="the width of each lane, in meters")
     dragway_parser.add_argument("--shoulder-width", default=1.0,
                                 type=float,
-                                help="The width of the road shoulder, \
+                                help="the width of the road shoulder,\
                                 in meters")
     dragway_parser.add_argument("--max-height", default=5.0,
                                 type=float,
-                                help="The maximum allowed height for the road\
-                                , in meters")
+                                help="the maximum allowed height for the road,\
+                                in meters")
 
     # Onramp subcommand
     subparsers.add_parser("onramp")
@@ -82,14 +85,12 @@ def main():
     # Monolane subcommand
     monolane_parser = subparsers.add_parser("monolane")
     monolane_parser.add_argument("--filename",
-                                 help="Monolane file path",
+                                 help="monolane file path",
                                  required=True)
 
     args = parser.parse_args()
 
     road_type = args.road_type
-
-    launcher = Launcher()
 
     simulator = AutomotiveSimulator()
 
@@ -105,7 +106,13 @@ def main():
     elif road_type == "onramp":
         builder.AddOnramp()
     elif road_type == "monolane":
-        builder.LoadMonolane(args.filename)
+        try:
+            builder.AddMonolaneFromFile(args.filename)
+        except RuntimeError, error:
+            print("There was an error trying to load the monolane file:")
+            print(str(error))
+            print("Exiting the simulation")
+            sys.exit()
     else:
         raise RuntimeError("Option {} not recognized".format(road_type))
 

--- a/backend/python_bindings.cc
+++ b/backend/python_bindings.cc
@@ -53,7 +53,7 @@ PYBIND11_MODULE(python_bindings, m) {
       .def(py::init<AutomotiveSimulator<double>*, double, double>())
       .def("AddDragway", &RoadBuilder<double>::AddDragway)
       .def("AddOnramp", &RoadBuilder<double>::AddOnramp)
-      .def("LoadMonolane", &RoadBuilder<double>::LoadMonolane);
+      .def("AddMonolaneFromFile", &RoadBuilder<double>::AddMonolaneFromFile);
 
   py::class_<AutomotiveSimulator<double>>(m, "AutomotiveSimulator")
       .def(py::init(

--- a/backend/road_builder.h
+++ b/backend/road_builder.h
@@ -86,7 +86,7 @@ class DELPHYNE_BACKEND_VISIBLE RoadBuilder {
 
   /// @brief Adds a monolane-based road network, loading it from the specified
   /// file path
-  void LoadMonolane(const std::string& file_path) {
+  void AddMonolaneFromFile(const std::string& file_path) {
     auto road_geometry = drake::maliput::monolane::LoadFile(file_path);
     simulator_->SetRoadGeometry(std::move(road_geometry));
   }


### PR DESCRIPTION
This PR adds the ability to load a monolane road geometry from a file. It also tweaks a bit the road loading python demo to be more flexible when configuring the dragway. If/once #303 is merged we will need to tweak a bit the names.