### PR TITLE
Fixed a flaky sim runner test.

### DIFF
--- a/backend/test/simulation_runner_test.cc
+++ b/backend/test/simulation_runner_test.cc
@@ -44,6 +44,9 @@ class SimulationRunnerTest : public ::testing::Test {
 
     // Calling node_.Request() immediately after Advertise() sometimes causes
     // that call to hang: waiting fixes this.
+    // TODO(nventuro): once ign-transport issue #84 is resolved, this should be
+    // changed according to what comes out of that discussion.
+    // https://bitbucket.org/ignitionrobotics/ign-transport/issues/84/hang-when-calling-noderequest
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 


### PR DESCRIPTION
After trying many different things, I noticed the only thing my solutions had in common was a small delay after calling `Advertise()`. I'm guessing calling `Request()` on a node that is still starting to advertise is what causes ignition to hang, but I have not found anything related in their docs, nor in any open issues.

I've run over 3000 iterations of the test suite after applying this fix, with no failures, but I'm unsure as to what the underlying issue might be.

@caguero is this behavior expected, or have we found a bug in ignition transport? I still get hangs even if a different thread calls `Request()`, which begs the question: how can `Advertise()` be safely called without knowing when a `Request()` call will happen? I tried supplying smaller `timeout` values to `Request()` (both 0 and 1ms), but the hang is still there. Is there some query that can be made to know when a service is 'ready'? 

Fixes #281 