### PR TITLE
Added absolute timeout to TestLcmOutput test

### DIFF
--- a/backend/test/automotive_simulator_test.cc
+++ b/backend/test/automotive_simulator_test.cc
@@ -611,11 +611,8 @@ GTEST_TEST(AutomotiveSimulatorTest, TestLcmOutput) {
     // This prevents the test to fall into a possible deadlock state.
     status = cv.wait_for(lck, std::chrono::milliseconds(kTimeoutMillis));
     if (status == std::cv_status::timeout) {
-      ::testing::AssertionResult has_timed_out =
-          ::testing::AssertionSuccess()
-          << "Condition variable timed out after waiting for "
-          << kTimeoutMillis << "ms.";
-      ASSERT_FALSE(has_timed_out);
+      FAIL() << "Condition variable timed out after waiting for "
+             << kTimeoutMillis << "ms.";
     }
   }
 


### PR DESCRIPTION
Fixes #287 
- Prevents the automotive simulator's test "TestLcmOutput" to fall into a possible deadlock when waiting for a condition variable to be met.
- Raises a custom gtest message if the test fails, expressing it failed because of a timeout.  