### PR TITLE
Scene publisher bugfix

### DIFF
--- a/backend/automotive_simulator.cc
+++ b/backend/automotive_simulator.cc
@@ -582,14 +582,10 @@ void AutomotiveSimulator<T>::Build() {
   // Which is then published over a scene topic to update the scene tree widget
   // of the visualizer. Because this information is not needed at the same
   // frequency the simulation runs at, the publishing frequency is reduced.
-  //
-  // TODO(basicNew): Temporary disabling this as it is breaking the UI. To be
-  // fixed ASAP.
-  //
-  // auto scene_publisher =
-  // builder_->template AddSystem<IgnPublisherSystem<ignition::msgs::Scene>>(
-  //        "scene", kScenePublishPeriodMs);
-  // builder_->Connect(*scene_builder, *scene_publisher);
+  auto scene_publisher =
+      builder_->template AddSystem<IgnPublisherSystem<ignition::msgs::Scene>>(
+          "scene", kScenePublishPeriodMs);
+  builder_->Connect(*scene_builder, *scene_publisher);
 
   pose_bundle_output_port_ =
       builder_->ExportOutput(aggregator_->get_output_port(0));

--- a/backend/scene_system.cc
+++ b/backend/scene_system.cc
@@ -15,6 +15,10 @@ void SceneSystem::CalcSceneMessage(
     ignition::msgs::Scene* scene_message) const {
   DELPHYNE_DEMAND(scene_message != nullptr);
 
+  // Clears old scene state from the previous CalcSceneMessage call.
+  // @see DeclareAbstractOutputPort
+  scene_message->Clear();
+
   const drake::systems::AbstractValue* input = EvalAbstractInput(context, 0);
   const auto& models = input->GetValue<ignition::msgs::Model_V>();
 

--- a/backend/test/simulation_runner_test.cc
+++ b/backend/test/simulation_runner_test.cc
@@ -189,7 +189,7 @@ TEST_F(SimulationRunnerTest, TestRequestStepWhenNotStarted) {
   // We need this flag for safe multithreaded death tests
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(sim_runner_->RequestMultiStep(1u),
-      "condition 'enabled_' failed.");
+               "condition 'enabled_' failed.");
 }
 
 // @brief Asserts that the execution breaks if a Start() is requested twice
@@ -218,7 +218,7 @@ TEST_F(SimulationRunnerTest, TestRequestStepWhenUnPaused) {
   EXPECT_FALSE(sim_runner_->IsPaused());
 
   EXPECT_DEATH(sim_runner_->RequestMultiStep(10u),
-      "condition 'paused_' failed.");
+               "condition 'paused_' failed.");
 }
 
 // @brief Checks that RunSyncFor executes the simulation for the expected

--- a/backend/translation_systems/lcm_viewer_draw_to_ign_model_v.cc
+++ b/backend/translation_systems/lcm_viewer_draw_to_ign_model_v.cc
@@ -28,7 +28,7 @@ void LcmViewerDrawToIgnModelV::DoDrakeToIgnTranslation(
       MillisToIgnitionTime(lcm_message.timestamp));
 
   // Clears state from the previous call.
-  // @see LcmToIgn::DoDrakeToIgnTranslation
+  // @see DrakeToIgn::DoDrakeToIgnTranslation
   ign_message->Clear();
 
   std::map<int32_t, ignition::msgs::Model*> models;


### PR DESCRIPTION
Objects that are stored in Drake system output ports are not re-constructed on each sim tick, so old state needs to be cleared before they are used (unless all fields are explicitly re-written, as is usually the case in Drake).

Closes #324 
Closes ToyotaResearchInstitute/delphyne-gui#78