### PR TITLE
Removed duplicated python scripts install

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -206,10 +206,6 @@ install(PROGRAMS
     ${CMAKE_INSTALL_PREFIX}/bin
 )
 
-# Launcher
-install(FILES python/launcher.py DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python2.7/site-packages/launcher)
-install(PROGRAMS python/demo_launcher.py DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
-
 ##############################################################################
 # C++ tests.
 ##############################################################################


### PR DESCRIPTION
These two lines installed duplicated versions of the same files (one in a different directory, and the other was a mere duplicated), so I just removed them.