### PR TITLE
Use drake's pybind11

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -1,6 +1,5 @@
 include (${project_cmake_dir}/Utils.cmake)
 include_directories(${PYTHON_INCLUDE_DIRS})
-include(${CMAKE_INSTALL_PREFIX}/share/cmake/pybind11/pybind11Tools.cmake)
 
 ##############################################################################
 # Common Libraries

--- a/scripts/continuous_integration/jenkins/build
+++ b/scripts/continuous_integration/jenkins/build
@@ -18,12 +18,6 @@ mkdir -p build
 
 pushd build
 
-mkdir -p pybind11
-pushd pybind11
-CXX=$COMPILER_PATH cmake ../../workspace/pybind11 -DCMAKE_INSTALL_PREFIX=../../install -DPYBIND11_TEST=False
-make -j$JOBS VERBOSE=1 install
-popd # pybind11
-
 for dep in ign_cmake ign_tools ign_common ign_msgs ign_transport ign_rendering ign_gui ; do
     mkdir -p $dep
     pushd $dep


### PR DESCRIPTION
This PR goes hand-with-hand with [delphyne-gui's #85](https://github.com/ToyotaResearchInstitute/delphyne-gui/pull/85) and fixes the first item from #344 .
- Removes the build/install instructions for Jenkins
- Fixes the lib path required to find drake's installed pybind11 copy.