### PR TITLE
[infra] undo remaining vestiges of visibility

### DIFF
--- a/backend/agent_plugin_base.h
+++ b/backend/agent_plugin_base.h
@@ -30,7 +30,7 @@ namespace backend {
 ///           template types are 'double', 'drake::AutoDiffXd', and
 ///           'drake::symbolic::Expression'.
 template <typename T>
-class DELPHYNE_BACKEND_VISIBLE AgentPluginBase
+class AgentPluginBase
     : public drake::systems::LeafSystem<T> {
  public:
   virtual ~AgentPluginBase() {}
@@ -83,7 +83,7 @@ typedef delphyne::backend::AgentPluginBase<::drake::symbolic::Expression>
 ///           template types are 'double', 'drake::AutoDiffXd', and
 ///           'drake::symbolic::Expression'.
 template <typename T>
-class DELPHYNE_BACKEND_VISIBLE AgentPluginFactoryBase {
+class AgentPluginFactoryBase {
  public:
   /// The `Create` method is used to get a std::unique_ptr of the concrete
   /// class that inherited from from AgentPluginBase.

--- a/backend/agent_plugin_loader.h
+++ b/backend/agent_plugin_loader.h
@@ -19,7 +19,7 @@ namespace backend {
 /// initialized.  See `agent_plugin_base.h` for more information about the
 /// methods that a loadable agent need to implement to get loaded in.
 template <typename T>
-DELPHYNE_BACKEND_VISIBLE std::unique_ptr<delphyne::backend::AgentPluginBase<T>>
+std::unique_ptr<delphyne::backend::AgentPluginBase<T>>
 LoadPlugin(const std::string& file_name);
 }  // namespace backend
 }  // namespace delphyne

--- a/backend/road_builder.h
+++ b/backend/road_builder.h
@@ -25,7 +25,7 @@ namespace backend {
 ///
 /// @tparam T must be a valid Eigen ScalarType.
 template <typename T>
-class DELPHYNE_BACKEND_VISIBLE RoadBuilder {
+class RoadBuilder {
  public:
   /// @brief Default constructor.
   ///

--- a/backend/scene_builder_system.h
+++ b/backend/scene_builder_system.h
@@ -34,7 +34,7 @@ namespace backend {
 ///
 /// They are already available to link against in the containing library.
 template <typename T>
-class DELPHYNE_BACKEND_VISIBLE SceneBuilderSystem
+class SceneBuilderSystem
     : public drake::systems::LeafSystem<T> {
  public:
   SceneBuilderSystem();

--- a/backend/scene_system.h
+++ b/backend/scene_system.h
@@ -17,7 +17,7 @@ namespace backend {
 
 /// @brief A system that creates an ignition Scene message from a Model_V
 /// message.
-class DELPHYNE_BACKEND_VISIBLE SceneSystem
+class SceneSystem
     : public drake::systems::LeafSystem<double> {
  public:
   SceneSystem();

--- a/backend/system.h
+++ b/backend/system.h
@@ -15,36 +15,6 @@
 #define DELPHYNE_BACKEND_FORCEINLINE
 #endif
 
-/// \def DELPHYNE_BACKEND_VISIBLE
-/// Use to represent "symbol visible" if supported
-
-/// \def DELPHYNE_BACKEND_HIDDEN
-/// Use to represent "symbol hidden" if supported
-#if defined _WIN32 || defined __CYGWIN__
-#ifdef BUILDING_DLL
-#ifdef __GNUC__
-#define DELPHYNE_BACKEND_VISIBLE __attribute__((dllexport))
-#else
-#define DELPHYNE_BACKEND_VISIBLE __declspec(dllexport)
-#endif
-#else
-#ifdef __GNUC__
-#define DELPHYNE_BACKEND_VISIBLE __attribute__((dllimport))
-#else
-#define DELPHYNE_BACKEND_VISIBLE __declspec(dllimport)
-#endif
-#endif
-#define DELPHYNE_BACKEND_HIDDEN
-#else
-#if __GNUC__ >= 4
-#define DELPHYNE_BACKEND_VISIBLE __attribute__((visibility("default")))
-#define DELPHYNE_BACKEND_HIDDEN __attribute__((visibility("hidden")))
-#else
-#define DELPHYNE_BACKEND_VISIBLE
-#define DELPHYNE_BACKEND_HIDDEN
-#endif
-#endif
-
 /// \def DELPHYNE_ASSERT
 /// Used to declare an assertion. Will quit execution otherwise.
 

--- a/backend/test/helpers.h
+++ b/backend/test/helpers.h
@@ -18,12 +18,12 @@ namespace test {
 // Generates a pre-loaded lcmt_viewer_draw message.
 //
 // @return a loaded lcmt_viewer_draw message.
-DELPHYNE_BACKEND_VISIBLE drake::lcmt_viewer_draw BuildPreloadedDrawMsg();
+drake::lcmt_viewer_draw BuildPreloadedDrawMsg();
 
 // Generates a pre-loaded Model_V message.
 //
 // @return a loaded Model_V message.
-DELPHYNE_BACKEND_VISIBLE ignition::msgs::Model_V BuildPreloadedModelVMsg();
+ignition::msgs::Model_V BuildPreloadedModelVMsg();
 
 // Asserts that all the array-iterable values from
 // lcm_msg matches the content of the ign_models object.
@@ -31,7 +31,7 @@ DELPHYNE_BACKEND_VISIBLE ignition::msgs::Model_V BuildPreloadedModelVMsg();
 // @param lcm_msg An lcm viewer draw message with the desired values.
 // @param ign_models An ignition messages Model_V with the translated values.
 // @return a google test's AssertionResult.
-DELPHYNE_BACKEND_VISIBLE::testing::AssertionResult CheckMsgTranslation(
+::testing::AssertionResult CheckMsgTranslation(
     const drake::lcmt_viewer_draw& lcm_msg,
     const ignition::msgs::Model_V& ign_models);
 
@@ -41,7 +41,7 @@ DELPHYNE_BACKEND_VISIBLE::testing::AssertionResult CheckMsgTranslation(
 // @param lcm_msg An lcm viewer draw message with the desired values.
 // @param ign_models An ignition messages Scene with the translated values.
 // @return a google test's AssertionResult.
-DELPHYNE_BACKEND_VISIBLE::testing::AssertionResult CheckMsgTranslation(
+::testing::AssertionResult CheckMsgTranslation(
     const drake::lcmt_viewer_draw& lcm_msg, const ignition::msgs::Scene& scene);
 
 // Asserts that the position values found on the original lcm message are
@@ -64,7 +64,7 @@ DELPHYNE_BACKEND_VISIBLE::testing::AssertionResult CheckMsgTranslation(
     const ignition::msgs::Pose& pose, const drake::lcmt_viewer_draw& lcm_msg,
     int lcm_index, double tolerance);
 
-DELPHYNE_BACKEND_VISIBLE::testing::AssertionResult CheckProtobufMsgEquality(
+::testing::AssertionResult CheckProtobufMsgEquality(
     const google::protobuf::MessageLite& lhs,
     const google::protobuf::MessageLite& rhs);
 

--- a/backend/time_conversion.cc
+++ b/backend/time_conversion.cc
@@ -73,8 +73,7 @@ ignition::msgs::Time SecsToIgnitionTime(double secs) {
   return ign_time;
 }
 
-DELPHYNE_BACKEND_VISIBLE int64_t
-IgnitionTimeToMillis(const ignition::msgs::Time ign_time) {
+int64_t IgnitionTimeToMillis(const ignition::msgs::Time ign_time) {
   return SecsAndNanosToMillis(ign_time.sec(), ign_time.nsec());
 }
 

--- a/backend/time_conversion.h
+++ b/backend/time_conversion.h
@@ -20,7 +20,7 @@ namespace backend {
 /// @param[out] A pair of integers containing the translated
 /// time value composed by seconds and nanoseconds.
 
-DELPHYNE_BACKEND_VISIBLE std::pair<int64_t, int64_t> MicrosToSecsAndNanos(
+std::pair<int64_t, int64_t> MicrosToSecsAndNanos(
     int64_t micros);
 
 /// @brief Converts from an integer value in milliseconds to a
@@ -30,7 +30,7 @@ DELPHYNE_BACKEND_VISIBLE std::pair<int64_t, int64_t> MicrosToSecsAndNanos(
 /// milliseconds.
 /// @param[out] A pair of integers containing the translated
 /// time value composed by seconds and nanoseconds.
-DELPHYNE_BACKEND_VISIBLE std::pair<int64_t, int64_t> MillisToSecsAndNanos(
+std::pair<int64_t, int64_t> MillisToSecsAndNanos(
     int64_t millis);
 
 /// @brief Converts from a double value in seconds to a pair of
@@ -40,7 +40,7 @@ DELPHYNE_BACKEND_VISIBLE std::pair<int64_t, int64_t> MillisToSecsAndNanos(
 /// in seconds.
 /// @param[out] A pair of integers containing the translated
 /// time value composed by seconds and nanoseconds.
-DELPHYNE_BACKEND_VISIBLE std::pair<int64_t, int64_t> SecsToSecsAndNanos(
+std::pair<int64_t, int64_t> SecsToSecsAndNanos(
     double time);
 
 /// @brief Converts from a pair of integers containing independent
@@ -52,7 +52,7 @@ DELPHYNE_BACKEND_VISIBLE std::pair<int64_t, int64_t> SecsToSecsAndNanos(
 /// in nanoseconds to translate.
 /// @param[out] A pair of integers containing the translated
 /// time value composed by seconds and nanoseconds.
-DELPHYNE_BACKEND_VISIBLE double SecsAndNanosToMillis(int64_t secs,
+double SecsAndNanosToMillis(int64_t secs,
                                                      int64_t nsecs);
 
 /// @brief Generates and returns an ignition::msgs::Time from a given
@@ -61,7 +61,7 @@ DELPHYNE_BACKEND_VISIBLE double SecsAndNanosToMillis(int64_t secs,
 /// milliseconds.
 /// @param[out] An ignition messages Time value composed by the value
 /// in seconds and nanoseconds translated from the milliseconds' input.
-DELPHYNE_BACKEND_VISIBLE ignition::msgs::Time MillisToIgnitionTime(
+ignition::msgs::Time MillisToIgnitionTime(
     int64_t millis);
 
 /// @brief Generates and returns an ignition::msgs::Time from a given
@@ -70,7 +70,7 @@ DELPHYNE_BACKEND_VISIBLE ignition::msgs::Time MillisToIgnitionTime(
 /// microseconds.
 /// @param[out] An ignition messages Time value composed by the value
 /// in seconds and nanoseconds translated from the microseconds' input.
-DELPHYNE_BACKEND_VISIBLE ignition::msgs::Time MicrosToIgnitionTime(
+ignition::msgs::Time MicrosToIgnitionTime(
     int64_t micros);
 
 /// @brief Generates and returns an ignition::msgs::Time from a given
@@ -79,14 +79,13 @@ DELPHYNE_BACKEND_VISIBLE ignition::msgs::Time MicrosToIgnitionTime(
 /// in seconds.
 /// @param[out] An ignition messages Time value composed by the value
 /// in seconds and nanoseconds translated from the seconds' double input.
-DELPHYNE_BACKEND_VISIBLE ignition::msgs::Time SecsToIgnitionTime(double secs);
+ignition::msgs::Time SecsToIgnitionTime(double secs);
 
 /// @brief Generates and returns an integer value in milliseconds.
 /// @param[in] ign_time an ignition messages Time object.
 /// @param[out] An integer value in milliseconds representing the
 /// total time contained in the ignition message.
-DELPHYNE_BACKEND_VISIBLE int64_t
-IgnitionTimeToMillis(const ignition::msgs::Time ign_time);
+int64_t IgnitionTimeToMillis(const ignition::msgs::Time ign_time);
 
 }  // namespace backend
 }  // namespace delphyne

--- a/backend/translation_systems/drake_driving_command_to_ign.h
+++ b/backend/translation_systems/drake_driving_command_to_ign.h
@@ -17,7 +17,7 @@ namespace translation_systems {
 
 /// @brief A system that translates Drake driving command messages to ignition
 /// driving command messages.
-class DELPHYNE_BACKEND_VISIBLE DrakeDrivingCommandToIgn
+class DrakeDrivingCommandToIgn
     : public DrakeToIgn<drake::automotive::DrivingCommand<double>,
                         ignition::msgs::AutomotiveDrivingCommand> {
  public:

--- a/backend/translation_systems/drake_simple_car_state_to_ign.h
+++ b/backend/translation_systems/drake_simple_car_state_to_ign.h
@@ -17,7 +17,7 @@ namespace translation_systems {
 
 /// @brief A system that translates Drake simple car state messages to ignition
 /// simple car state messages.
-class DELPHYNE_BACKEND_VISIBLE DrakeSimpleCarStateToIgn
+class DrakeSimpleCarStateToIgn
     : public DrakeToIgn<drake::automotive::SimpleCarState<double>,
                         ignition::msgs::SimpleCarState> {
  public:

--- a/backend/translation_systems/ign_driving_command_to_drake.h
+++ b/backend/translation_systems/ign_driving_command_to_drake.h
@@ -17,7 +17,7 @@ namespace translation_systems {
 
 /// @brief A system that translates ignition driving command messages to Drake
 /// driving command messages.
-class DELPHYNE_BACKEND_VISIBLE IgnDrivingCommandToDrake
+class IgnDrivingCommandToDrake
     : public IgnToDrake<ignition::msgs::AutomotiveDrivingCommand,
                         drake::automotive::DrivingCommand<double>> {
  protected:

--- a/backend/translation_systems/ign_model_v_to_lcm_viewer_draw.h
+++ b/backend/translation_systems/ign_model_v_to_lcm_viewer_draw.h
@@ -15,7 +15,7 @@ namespace translation_systems {
 
 /// @brief A system that translates ignition Model_V messages to LCM viewer draw
 /// messages.
-class DELPHYNE_BACKEND_VISIBLE IgnModelVToLcmViewerDraw
+class IgnModelVToLcmViewerDraw
     : public IgnToDrake<ignition::msgs::Model_V, drake::lcmt_viewer_draw> {
  protected:
   // @brief @see IgnToDrake::DoIgnToDrakeTranslation.

--- a/backend/translation_systems/ign_simple_car_state_to_drake.h
+++ b/backend/translation_systems/ign_simple_car_state_to_drake.h
@@ -17,7 +17,7 @@ namespace translation_systems {
 
 /// @brief A system that translates ignition simple car state messages to Drake
 /// simple car state messages.
-class DELPHYNE_BACKEND_VISIBLE IgnSimpleCarStateToDrake
+class IgnSimpleCarStateToDrake
     : public IgnToDrake<ignition::msgs::SimpleCarState,
                         drake::automotive::SimpleCarState<double>> {
  protected:

--- a/backend/translation_systems/lcm_viewer_draw_to_ign_model_v.h
+++ b/backend/translation_systems/lcm_viewer_draw_to_ign_model_v.h
@@ -15,7 +15,7 @@ namespace translation_systems {
 
 /// @brief A system that translates LCM viewer draw messages to ignition
 /// Model_V.
-class DELPHYNE_BACKEND_VISIBLE LcmViewerDrawToIgnModelV
+class LcmViewerDrawToIgnModelV
     : public DrakeToIgn<drake::lcmt_viewer_draw, ignition::msgs::Model_V> {
  protected:
   // @brief @see DrakeToIgn::DoLcmToIgnTranslation.

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -140,11 +140,3 @@ endif()
 # if (NOT PYTHON_MODULE_EXTENSION MATCHES "cpython")
 #   BUILD_ERROR("pybind didn't find a cpython interpreter: ${PYTHON_MODULE_EXTENSION}")
 # endif()
-
-#################################################
-# Macro to check for visibility capability in compiler
-# Original idea from: https://gitorious.org/ferric-cmake-stuff/
-macro (check_gcc_visibility)
-  include (CheckCXXCompilerFlag)
-  check_cxx_compiler_flag(-fvisibility=hidden GCC_SUPPORTS_VISIBILITY)
-endmacro()


### PR DESCRIPTION
If we're not going to use it, eliminate it so it doesn't create
confusion or noise. If we do decide to use it, we can easily pull
it back in.