### PR TITLE
User lowercase for the Ignition topics

### DIFF
--- a/backend/automotive_demo.cc
+++ b/backend/automotive_demo.cc
@@ -20,11 +20,11 @@ namespace {
 
 // Generates a channel name based on a given string.
 std::string MakeChannelName(const std::string& name) {
-  const std::string default_prefix{"driving_command"};
+  const std::string default_prefix{"teleop"};
   if (name.empty()) {
     return default_prefix;
   }
-  return default_prefix + "_" + name;
+  return default_prefix + "/" + name;
 }
 
 drake::automotive::Curve2<double> MakeCurve(double radius, double inset) {

--- a/backend/automotive_simulator.cc
+++ b/backend/automotive_simulator.cc
@@ -495,7 +495,7 @@ void AutomotiveSimulator<T>::AddPublisher(
                     simple_car_translator->get_input_port(0));
 
   const std::string channel =
-      std::to_string(vehicle_number) + "_simple_car_state";
+      "agents/" + std::to_string(vehicle_number) + "/state";
   auto simple_car_publisher = builder_->template AddSystem<
       IgnPublisherSystem<ignition::msgs::SimpleCarState>>(channel);
 
@@ -570,7 +570,7 @@ void AutomotiveSimulator<T>::Build() {
 
   auto model_v_publisher =
       builder_->template AddSystem<IgnPublisherSystem<ignition::msgs::Model_V>>(
-          "drake_viewer_draw");
+          "visualizer/scene_update");
 
   // The translated ignition message is then published.
   builder_->Connect(*viewer_draw_translator, *model_v_publisher);

--- a/backend/python/simulation_utils.py
+++ b/backend/python/simulation_utils.py
@@ -71,7 +71,7 @@ def build_simple_car_simulator(initial_positions=None):
         state = SimpleCarState()
         state.y = car_position[0]
         state.x = car_position[1]
-        driving_command = "driving_command_" + str(car_id)
+        driving_command = "teleop/" + str(car_id)
         simulator.AddPriusSimpleCar(str(car_id), driving_command, state)
         car_id += 1
     return simulator

--- a/loadable_agents/LoadableMobilControlledSimpleCar.cc
+++ b/loadable_agents/LoadableMobilControlledSimpleCar.cc
@@ -217,7 +217,7 @@ class LoadableMobilControlledSimpleCarDouble final
         translation_systems::DrakeSimpleCarStateToIgn>();
 
     const std::string car_state_channel =
-        std::to_string(id) + "_simple_car_state";
+        "agents/" + std::to_string(id) + "/state";
     auto car_state_publisher = builder->template AddSystem<
         IgnPublisherSystem<ignition::msgs::SimpleCarState>>(car_state_channel);
 

--- a/loadable_agents/LoadablePriusSimpleCar.cc
+++ b/loadable_agents/LoadablePriusSimpleCar.cc
@@ -111,7 +111,7 @@ class LoadablePriusSimpleCarDouble final
       override {
     igndbg << "LoadablePriusSimpleCar configure" << std::endl;
 
-    std::string command_channel = "driving_command_" + name;
+    std::string command_channel = "teleop/" + name;
     auto driving_command_subscriber = builder->template AddSystem<
         IgnSubscriberSystem<ignition::msgs::AutomotiveDrivingCommand>>(
         command_channel);
@@ -136,7 +136,7 @@ class LoadablePriusSimpleCarDouble final
         translation_systems::DrakeSimpleCarStateToIgn>();
 
     const std::string car_state_channel =
-        std::to_string(id) + "_simple_car_state";
+        "agents/" + std::to_string(id) + "/state";
     auto car_state_publisher = builder->template AddSystem<
         IgnPublisherSystem<ignition::msgs::SimpleCarState>>(car_state_channel);
 

--- a/loadable_agents/LoadablePriusTrajectoryCar.cc
+++ b/loadable_agents/LoadablePriusTrajectoryCar.cc
@@ -164,7 +164,7 @@ class LoadablePriusTrajectoryCarDouble final
         builder->AddSystem<translation_systems::DrakeSimpleCarStateToIgn>();
 
     const std::string car_state_channel =
-        std::to_string(id) + "_simple_car_state";
+        "agents/" + std::to_string(id) + "/state";
     auto car_state_publisher =
         builder->AddSystem<IgnPublisherSystem<ignition::msgs::SimpleCarState>>(
             car_state_channel);

--- a/test/regression/cpp/automotive_simulator_test.cc
+++ b/test/regression/cpp/automotive_simulator_test.cc
@@ -126,7 +126,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestPriusSimpleCar) {
 
   ignition::transport::Node node;
 
-  node.Subscribe<ignition::msgs::SimpleCarState>("/0_simple_car_state",
+  node.Subscribe<ignition::msgs::SimpleCarState>("agents/0/state",
                                                  callback);
 
   const std::string kCommandChannelName = "DRIVING_COMMAND";
@@ -202,7 +202,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestPriusSimpleCarInitialState) {
 
   ignition::transport::Node node;
 
-  node.Subscribe<ignition::msgs::SimpleCarState>("/0_simple_car_state",
+  node.Subscribe<ignition::msgs::SimpleCarState>("agents/0/state",
                                                  callback);
 
   simulator->Start();
@@ -263,7 +263,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestMobilControlledSimpleCar) {
   EXPECT_EQ(id_decoy2, 2);
 
   // Setup the an ignition callback to store the latest ignition::msgs::Model_V
-  // that is published to /drake_viewer_draw.
+  // that is published to /visualizer/scene_update.
   ignition::msgs::Model_V draw_message;
 
   std::function<void(const ignition::msgs::Model_V& ign_message)>
@@ -274,7 +274,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestMobilControlledSimpleCar) {
 
   ignition::transport::Node node;
 
-  node.Subscribe<ignition::msgs::Model_V>("/drake_viewer_draw",
+  node.Subscribe<ignition::msgs::Model_V>("visualizer/scene_update",
                                           viewer_draw_callback);
 
   // Finish all initialization, so that we can test the post-init state.
@@ -315,7 +315,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestPriusTrajectoryCar) {
   EXPECT_EQ(id2, 1);
 
   // Setup the an ignition callback to store the latest ignition::msgs::Model_V
-  // that is published to /drake_viewer_draw.
+  // that is published to /visualizer/scene_update.
   ignition::msgs::Model_V draw_message;
 
   std::function<void(const ignition::msgs::Model_V& ign_message)>
@@ -326,7 +326,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestPriusTrajectoryCar) {
 
   ignition::transport::Node node;
 
-  node.Subscribe<ignition::msgs::Model_V>("/drake_viewer_draw",
+  node.Subscribe<ignition::msgs::Model_V>("visualizer/scene_update",
                                           viewer_draw_callback);
 
   // Finish all initialization, so that we can test the post-init state.
@@ -461,7 +461,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestMaliputRailcar) {
   EXPECT_EQ(id, 0);
 
   // Setup the an ignition callback to store the latest ignition::msgs::Model_V
-  // that is published to /drake_viewer_draw
+  // that is published to /visualizer/scene_update
   ignition::msgs::Model_V draw_message;
 
   std::function<void(const ignition::msgs::Model_V& ign_message)>
@@ -472,7 +472,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestMaliputRailcar) {
 
   ignition::transport::Node node;
 
-  node.Subscribe<ignition::msgs::Model_V>("/drake_viewer_draw",
+  node.Subscribe<ignition::msgs::Model_V>("visualizer/scene_update",
                                           viewer_draw_callback);
 
   simulator->Start();
@@ -546,7 +546,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestLcmOutput) {
                                    0 /* start time */);
 
   // Setup the an ignition callback to store the latest ignition::msgs::Model_V
-  // that is published to /drake_viewer_draw
+  // that is published to /visualizer/scene_update
   ignition::msgs::Model_V draw_message;
 
   // Condition variable for critical section.
@@ -572,7 +572,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestLcmOutput) {
 
   ignition::transport::Node node;
 
-  node.Subscribe<ignition::msgs::Model_V>("/drake_viewer_draw",
+  node.Subscribe<ignition::msgs::Model_V>("visualizer/scene_update",
                                           viewer_draw_callback);
 
   // Plus one to include the world.

--- a/test/regression/cpp/ign_publisher_system_test.cc
+++ b/test/regression/cpp/ign_publisher_system_test.cc
@@ -34,7 +34,7 @@ class IgnPublisherSystemTest : public ::testing::Test {
   // The received message.
   ignition::msgs::Model_V ign_msg_;
 
-  const std::string kTopicName = "drake_viewer_draw";
+  const std::string kTopicName = "visualizer/scene_update";
 
   void SetUp() override {
     handler_called_count_ = 0;

--- a/test/regression/cpp/ign_subscriber_system_test.cc
+++ b/test/regression/cpp/ign_subscriber_system_test.cc
@@ -21,7 +21,7 @@ namespace backend {
 // Creates an Ignition Subscriber System and publish a message, then checks that
 // it has been correctly received by the system.
 GTEST_TEST(IgnSubscriberSystemTest, SubscribeTest) {
-  const std::string kTopicName{"drake_viewer_draw"};
+  const std::string kTopicName{"visualizer/scene_update"};
 
   // Subscriber system.
   IgnSubscriberSystem<ignition::msgs::Model_V> subscriber_system(kTopicName);


### PR DESCRIPTION
Use with [# 91](https://github.com/ToyotaResearchInstitute/delphyne-gui/pull/91) in Delphyne GUI.

The following topics/prefixes/suffixes have been converted to lowercase:

* `DRIVING_COMMAND`
* `SIMPLE_CAR_STATE`
* `DRAKE_VIEWER_DRAW`