### PR TITLE
Rename AddLoadableCar to AddLoadableAgent

### DIFF
--- a/backend/automotive_demo.cc
+++ b/backend/automotive_demo.cc
@@ -108,8 +108,8 @@ int main(int argc, char* argv[]) {
   drake::automotive::SimpleCarState<double> state2;
   state2.set_y(4.0);
   std::map<std::string, linb::any> simple_params;
-  if (simulator->AddLoadableCar("LoadablePriusSimpleCar", simple_params, "1",
-                                &state2) < 0) {
+  if (simulator->AddLoadableAgent("LoadablePriusSimpleCar", simple_params, "1",
+                                  &state2) < 0) {
     return 1;
   }
 
@@ -120,8 +120,8 @@ int main(int argc, char* argv[]) {
   drake::automotive::TrajectoryCarState<double> state3;
   state3.set_speed(std::get<1>(params));
   state3.set_position(std::get<2>(params));
-  if (simulator->AddLoadableCar("LoadablePriusTrajectoryCar", traj_params,
-                                "TrajectoryCar0", &state3) < 0) {
+  if (simulator->AddLoadableAgent("LoadablePriusTrajectoryCar", traj_params,
+                                  "TrajectoryCar0", &state3) < 0) {
     return 1;
   }
 
@@ -146,8 +146,8 @@ int main(int argc, char* argv[]) {
   std::map<std::string, linb::any> mobil_params;
   mobil_params["road"] = road_geometry;
   mobil_params["initial_with_s"] = true;
-  if (simulator->AddLoadableCar("LoadableMobilControlledSimpleCar",
-                                mobil_params, "MOBIL0", &state4) < 0) {
+  if (simulator->AddLoadableAgent("LoadableMobilControlledSimpleCar",
+                                  mobil_params, "MOBIL0", &state4) < 0) {
     return 1;
   }
 
@@ -164,8 +164,8 @@ int main(int argc, char* argv[]) {
   state5.set_s(0);
   state5.set_speed(1);
   maliput_params["initial_with_s"] = true;
-  if (simulator->AddLoadableCar("LoadableMaliputRailCar", maliput_params,
-                                "Maliput0", &state5) < 0) {
+  if (simulator->AddLoadableAgent("LoadableMaliputRailCar", maliput_params,
+                                  "Maliput0", &state5) < 0) {
     return 1;
   }
 

--- a/backend/automotive_simulator.h
+++ b/backend/automotive_simulator.h
@@ -84,17 +84,17 @@ class AutomotiveSimulator {
   /// @param parameters Parameters to be passed to the loadable module
   /// "configure" method.
   ///
-  /// @param name The car's name, which must be unique among all cars. Otherwise
-  /// a std::runtime_error will be thrown.
+  /// @param name The agent's name, which must be unique among all agents.
+  /// Otherwise a std::runtime_error will be thrown.
   ///
   /// @param initial_state The vehicle's initial state.
   ///
-  /// @return The ID of the car that was just added to the simulation, or -1 on
-  /// error.
-  int AddLoadableCar(const std::string& plugin,
-                     const std::map<std::string, linb::any>& parameters,
-                     const std::string& name,
-                     drake::systems::BasicVector<T>* initial_state);
+  /// @return The ID of the agent that was just added to the simulation, or -1
+  /// on error.
+  int AddLoadableAgent(const std::string& plugin,
+                       const std::map<std::string, linb::any>& parameters,
+                       const std::string& name,
+                       drake::systems::BasicVector<T>* initial_state);
 
   /// Adds a SimpleCar to this simulation visualized as a Toyota Prius. This
   /// includes its DrivingCommand LCM input.
@@ -190,9 +190,10 @@ class AutomotiveSimulator {
 
   int allocate_vehicle_number();
 
-  // Verifies that the provided `name` of a car is unique among all cars that
-  // have been added to the `AutomotiveSimulator`. Throws a std::runtime_error
-  // if it is not unique meaning a car of the same name was already added.
+  // Verifies that the provided `name` of an agent is unique among all agents
+  // that have been added to the `AutomotiveSimulator`. Throws a
+  // std::runtime_error if it is not unique meaning an agent of the same name
+  // was already added.
   void CheckNameUniqueness(const std::string& name);
 
   // Connects the provided pose and velocity output ports of a vehicle model to
@@ -227,7 +228,7 @@ class AutomotiveSimulator {
   void InitializeSceneGeometryAggregator();
 
   void InitializeSimpleCars();
-  void InitializeLoadableCars();
+  void InitializeLoadableAgents();
 
   // For both building and simulation.
   std::unique_ptr<drake::lcm::DrakeLcmInterface> lcm_{};
@@ -245,10 +246,10 @@ class AutomotiveSimulator {
            drake::automotive::SimpleCarState<T>>
       simple_car_initial_states_;
 
-  // Holds the desired initial states of each loadable vehicle. It is used to
+  // Holds the desired initial states of each loadable agent. It is used to
   // initialize the simulation's diagram's state.
   std::map<drake::systems::System<T>*, drake::systems::BasicVector<T>*>
-      loadable_car_initial_states_;
+      loadable_agent_initial_states_;
 
   // The output port of the Diagram that contains pose bundle information.
   int pose_bundle_output_port_{};
@@ -277,8 +278,8 @@ class AutomotiveSimulator {
 
   int next_vehicle_number_{0};
 
-  // Maps a vehicle id to a pointer to the system that implements the vehicle.
-  std::map<int, drake::systems::System<T>*> vehicles_;
+  // Maps an agent id to a pointer to the system that implements the agent.
+  std::map<int, drake::systems::System<T>*> agents_;
 
   // For simulation.
   std::unique_ptr<drake::systems::Diagram<T>> diagram_{};

--- a/backend/python_bindings.cc
+++ b/backend/python_bindings.cc
@@ -106,7 +106,7 @@ PYBIND11_MODULE(python_bindings, m) {
           [](void) { return std::make_unique<AutomotiveSimulator<double>>(); }))
       .def("Start", &AutomotiveSimulator<double>::Start)
       .def("AddPriusSimpleCar", &AutomotiveSimulator<double>::AddPriusSimpleCar)
-      .def("AddLoadableCar", &AutomotiveSimulator<double>::AddLoadableCar);
+      .def("AddLoadableAgent", &AutomotiveSimulator<double>::AddLoadableAgent);
 }
 
 }  // namespace

--- a/test/regression/cpp/automotive_simulator_test.cc
+++ b/test/regression/cpp/automotive_simulator_test.cc
@@ -81,8 +81,8 @@ TEST_F(AutomotiveSimulatorTest, TestGetScene) {
   SimpleCarState<double> initial_state;
 
   std::map<std::string, linb::any> simple_params;
-  simulator->AddLoadableCar("LoadablePriusSimpleCar", simple_params,
-                            "my_test_model", &initial_state);
+  simulator->AddLoadableAgent("LoadablePriusSimpleCar", simple_params,
+                              "my_test_model", &initial_state);
 
   simulator->Start();
   std::unique_ptr<ignition::msgs::Scene> scene = simulator->GetScene();
@@ -156,7 +156,7 @@ TEST_F(AutomotiveSimulatorTest, TestPriusSimpleCar) {
 
   drake::automotive::SimpleCarState<double> initial_state;
   std::map<std::string, linb::any> simple_params;
-  const int id = simulator->AddLoadableCar("LoadablePriusSimpleCar",
+  const int id = simulator->AddLoadableAgent("LoadablePriusSimpleCar",
                  simple_params, "Foo", &initial_state);
   EXPECT_EQ(id, 0);
 
@@ -211,8 +211,8 @@ TEST_F(AutomotiveSimulatorTest, TestPriusSimpleCarInitialState) {
   initial_state.set_velocity(kVelocity);
 
   std::map<std::string, linb::any> simple_params;
-  simulator->AddLoadableCar("LoadablePriusSimpleCar",
-                            simple_params, "My Test Model", &initial_state);
+  simulator->AddLoadableAgent("LoadablePriusSimpleCar",
+                              simple_params, "My Test Model", &initial_state);
 
   ignition::msgs::SimpleCarState state_message;
   std::function<void(const ignition::msgs::SimpleCarState& ign_message)>
@@ -269,7 +269,7 @@ TEST_F(AutomotiveSimulatorTest, TestMobilControlledSimpleCar) {
   std::map<std::string, linb::any> mobil_params;
   mobil_params["road"] = road;
   mobil_params["initial_with_s"] = true;
-  const int id_mobil = simulator->AddLoadableCar(
+  const int id_mobil = simulator->AddLoadableAgent(
       "LoadableMobilControlledSimpleCar", mobil_params, "MOBIL0",
       &simple_car_state);
   EXPECT_EQ(0, id_mobil);
@@ -285,7 +285,7 @@ TEST_F(AutomotiveSimulatorTest, TestMobilControlledSimpleCar) {
   maliput_params1["road"] = road;
   maliput_params1["lane_direction"] = &lane_direction1;
   maliput_params1["start_params"] = &start_params;
-  const int id_decoy1 = simulator->AddLoadableCar(
+  const int id_decoy1 = simulator->AddLoadableAgent(
       "LoadableMaliputRailCar", maliput_params1, "decoy1", &decoy_state);
   EXPECT_EQ(1, id_decoy1);
 
@@ -297,7 +297,7 @@ TEST_F(AutomotiveSimulatorTest, TestMobilControlledSimpleCar) {
   maliput_params2["road"] = road;
   maliput_params2["lane_direction"] = &lane_direction2;
   maliput_params2["start_params"] = &start_params;
-  const int id_decoy2 = simulator->AddLoadableCar(
+  const int id_decoy2 = simulator->AddLoadableAgent(
       "LoadableMaliputRailCar", maliput_params2, "decoy2", &decoy_state);
   EXPECT_EQ(2, id_decoy2);
 
@@ -356,9 +356,9 @@ TEST_F(AutomotiveSimulatorTest, TestPriusTrajectoryCar) {
   drake::automotive::TrajectoryCarState<double> stateBob;
   stateBob.set_speed(0.0);
   stateBob.set_position(0.0);
-  const int id1 = simulator->AddLoadableCar("LoadablePriusTrajectoryCar",
+  const int id1 = simulator->AddLoadableAgent("LoadablePriusTrajectoryCar",
       traj_params, "alice", &stateAlice);
-  const int id2 = simulator->AddLoadableCar("LoadablePriusTrajectoryCar",
+  const int id2 = simulator->AddLoadableAgent("LoadablePriusTrajectoryCar",
       traj_params, "bob", &stateBob);
 
   EXPECT_EQ(0, id1);
@@ -480,7 +480,7 @@ TEST_F(AutomotiveSimulatorTest, TestBadMaliputRailcars) {
   MaliputRailcarState<double> state;
 
   // Road geometry not set.
-  const int id1 = simulator->AddLoadableCar(
+  const int id1 = simulator->AddLoadableAgent(
       "LoadableMaliputRailCar", maliput_params, "foo", &state);
   EXPECT_LT(id1, 0);
 
@@ -494,7 +494,7 @@ TEST_F(AutomotiveSimulatorTest, TestBadMaliputRailcars) {
               std::numeric_limits<double>::epsilon() /* angular_tolerance */)));
 
   maliput_params["start_params"] = &params;
-  const int id2 = simulator->AddLoadableCar(
+  const int id2 = simulator->AddLoadableAgent(
       "LoadableMaliputRailCar", maliput_params, "bar", &state);
   EXPECT_LT(id2, 0);
 
@@ -511,7 +511,7 @@ TEST_F(AutomotiveSimulatorTest, TestBadMaliputRailcars) {
   maliput_params["lane_direction"] = &lane_direction3;
 
   // The provided initial lane is not within this simulation's RoadGeometry.
-  const int id3 = simulator->AddLoadableCar(
+  const int id3 = simulator->AddLoadableAgent(
       "LoadableMaliputRailCar", maliput_params, "bar2", &state);
   EXPECT_LT(id3, 0);
 }
@@ -546,7 +546,7 @@ TEST_F(AutomotiveSimulatorTest, TestMaliputRailcar) {
   maliput_params["start_params"] = &params;
   MaliputRailcarState<double> state;
 
-  const int id = simulator->AddLoadableCar(
+  const int id = simulator->AddLoadableAgent(
       "LoadableMaliputRailCar", maliput_params, "model_name", &state);
   EXPECT_GE(id, 0);
 
@@ -593,10 +593,10 @@ TEST_F(AutomotiveSimulatorTest, TestLcmOutput) {
 
   std::map<std::string, linb::any> simple_params;
   drake::automotive::SimpleCarState<double> simple_state;
-  simulator->AddLoadableCar("LoadablePriusSimpleCar", simple_params, "Model1",
-                            &simple_state);
-  simulator->AddLoadableCar("LoadablePriusSimpleCar", simple_params, "Model2",
-                            &simple_state);
+  simulator->AddLoadableAgent("LoadablePriusSimpleCar", simple_params, "Model1",
+                              &simple_state);
+  simulator->AddLoadableAgent("LoadablePriusSimpleCar", simple_params, "Model2",
+                              &simple_state);
 
   typedef Curve2<double> Curve2d;
   typedef Curve2d::Point2 Point2d;
@@ -608,9 +608,9 @@ TEST_F(AutomotiveSimulatorTest, TestLcmOutput) {
   drake::automotive::TrajectoryCarState<double> state;
   state.set_speed(1.0);
   state.set_position(0.0);
-  simulator->AddLoadableCar("LoadablePriusTrajectoryCar",
+  simulator->AddLoadableAgent("LoadablePriusTrajectoryCar",
       traj_params, "alice", &state);
-  simulator->AddLoadableCar("LoadablePriusTrajectoryCar",
+  simulator->AddLoadableAgent("LoadablePriusTrajectoryCar",
       traj_params, "bob", &state);
 
   // Setup the an ignition callback to store the latest ignition::msgs::Model_V
@@ -694,9 +694,9 @@ TEST_F(AutomotiveSimulatorTest, TestDuplicateVehicleNameException) {
 
   drake::automotive::SimpleCarState<double> simple_state;
   std::map<std::string, linb::any> simple_params;
-  EXPECT_NO_THROW(simulator->AddLoadableCar("LoadablePriusSimpleCar",
+  EXPECT_NO_THROW(simulator->AddLoadableAgent("LoadablePriusSimpleCar",
                       simple_params, "Model1", &simple_state));
-  EXPECT_THROW(simulator->AddLoadableCar("LoadablePriusSimpleCar",
+  EXPECT_THROW(simulator->AddLoadableAgent("LoadablePriusSimpleCar",
                       simple_params, "Model1", &simple_state),
                std::runtime_error);
 
@@ -710,13 +710,13 @@ TEST_F(AutomotiveSimulatorTest, TestDuplicateVehicleNameException) {
   drake::automotive::TrajectoryCarState<double> state;
   state.set_speed(1.0);
   state.set_position(0.0);
-  EXPECT_NO_THROW(simulator->AddLoadableCar("LoadablePriusTrajectoryCar",
+  EXPECT_NO_THROW(simulator->AddLoadableAgent("LoadablePriusTrajectoryCar",
       traj_params, "alice", &state));
 
-  EXPECT_THROW(simulator->AddLoadableCar("LoadablePriusTrajectoryCar",
+  EXPECT_THROW(simulator->AddLoadableAgent("LoadablePriusTrajectoryCar",
       traj_params, "alice", &state), std::runtime_error);
 
-  EXPECT_THROW(simulator->AddLoadableCar("LoadablePriusTrajectoryCar",
+  EXPECT_THROW(simulator->AddLoadableAgent("LoadablePriusTrajectoryCar",
       traj_params, "Model1", &state), std::runtime_error);
 
   const double kR{0.5};
@@ -740,15 +740,15 @@ TEST_F(AutomotiveSimulatorTest, TestDuplicateVehicleNameException) {
   maliput_params["lane_direction"] = &lane_direction;
   maliput_params["start_params"] = &params;
 
-  EXPECT_NO_THROW(simulator->AddLoadableCar(
+  EXPECT_NO_THROW(simulator->AddLoadableAgent(
       "LoadableMaliputRailCar", maliput_params, "Foo", &state));
 
   EXPECT_THROW(
-      simulator->AddLoadableCar(
+      simulator->AddLoadableAgent(
           "LoadableMaliputRailCar", maliput_params, "alice", &state),
       std::runtime_error);
   EXPECT_THROW(
-      simulator->AddLoadableCar(
+      simulator->AddLoadableAgent(
           "LoadableMaliputRailCar", maliput_params, "Model1", &state),
       std::runtime_error);
 }
@@ -781,11 +781,11 @@ TEST_F(AutomotiveSimulatorTest, TestRailcarVelocityOutput) {
   maliput_params["lane_direction"] = &lane_direction;
   maliput_params["start_params"] = &params;
 
-  const int alice_id = simulator->AddLoadableCar(
+  const int alice_id = simulator->AddLoadableAgent(
       "LoadableMaliputRailCar", maliput_params, "Alice", &alice_initial_state);
 
   MaliputRailcarState<double> bob_initial_state;
-  const int bob_id = simulator->AddLoadableCar(
+  const int bob_id = simulator->AddLoadableAgent(
       "LoadableMaliputRailCar", maliput_params, "Bob", &bob_initial_state);
 
   EXPECT_NO_THROW(simulator->Start());
@@ -814,10 +814,10 @@ TEST_F(AutomotiveSimulatorTest, TestBuild) {
 
   drake::automotive::SimpleCarState<double> simple_state;
   std::map<std::string, linb::any> simple_params;
-  simulator->AddLoadableCar("LoadablePriusSimpleCar", simple_params, "Model1",
-                            &simple_state);
-  simulator->AddLoadableCar("LoadablePriusSimpleCar", simple_params, "Model2",
-                            &simple_state);
+  simulator->AddLoadableAgent("LoadablePriusSimpleCar", simple_params, "Model1",
+                              &simple_state);
+  simulator->AddLoadableAgent("LoadablePriusSimpleCar", simple_params, "Model2",
+                              &simple_state);
 
   simulator->Build();
   EXPECT_FALSE(simulator->has_started());
@@ -834,10 +834,10 @@ TEST_F(AutomotiveSimulatorTest, TestBuild2) {
 
   drake::automotive::SimpleCarState<double> simple_state;
   std::map<std::string, linb::any> simple_params;
-  simulator->AddLoadableCar("LoadablePriusSimpleCar", simple_params, "Model1",
-                            &simple_state);
-  simulator->AddLoadableCar("LoadablePriusSimpleCar", simple_params, "Model2",
-                            &simple_state);
+  simulator->AddLoadableAgent("LoadablePriusSimpleCar", simple_params, "Model1",
+                              &simple_state);
+  simulator->AddLoadableAgent("LoadablePriusSimpleCar", simple_params, "Model2",
+                              &simple_state);
 
   simulator->Start(0.0);
   EXPECT_NO_THROW(simulator->GetDiagram());
@@ -851,8 +851,8 @@ TEST_F(AutomotiveSimulatorTest, TestNoLcm) {
 
   drake::automotive::SimpleCarState<double> simple_state;
   std::map<std::string, linb::any> simple_params;
-  simulator->AddLoadableCar("LoadablePriusSimpleCar", simple_params, "Model1",
-                            &simple_state);
+  simulator->AddLoadableAgent("LoadablePriusSimpleCar", simple_params, "Model1",
+                              &simple_state);
 
   simulator->Start();
   simulator->StepBy(1e-3);
@@ -873,22 +873,22 @@ TEST_F(AutomotiveSimulatorTest, TestNoLcm) {
                std::runtime_error);
 }
 
-// Tests that AddLoadableCar basically works.
-TEST_F(AutomotiveSimulatorTest, TestAddLoadableCarBasic) {
+// Tests that AddLoadableAgent basically works.
+TEST_F(AutomotiveSimulatorTest, TestAddLoadableAgentBasic) {
   auto simulator = std::make_unique<AutomotiveSimulator<double>>();
   const std::map<std::string, linb::any> params;
 
-  ASSERT_EQ(0, simulator->AddLoadableCar("LoadableExampleDouble", params,
-                                         "my_test_model", nullptr));
+  ASSERT_EQ(0, simulator->AddLoadableAgent("LoadableExampleDouble", params,
+                                           "my_test_model", nullptr));
 }
 
-// Tests that AddLoadableCar returns -1 when unable to find plugin.
-TEST_F(AutomotiveSimulatorTest, TestAddLoadableCarNonExistent) {
+// Tests that AddLoadableAgent returns -1 when unable to find plugin.
+TEST_F(AutomotiveSimulatorTest, TestAddLoadableAgentNonExistent) {
   auto simulator = std::make_unique<AutomotiveSimulator<double>>();
   const std::map<std::string, linb::any> params;
 
-  ASSERT_EQ(-1, simulator->AddLoadableCar("NonExistentPlugin", params,
-                                          "my_test_model", nullptr));
+  ASSERT_EQ(-1, simulator->AddLoadableAgent("NonExistentPlugin", params,
+                                            "my_test_model", nullptr));
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
I think the term agent is more generic, as we're not limited to cars or vehicles.

I forgot to follow-up in the last pull request about `AddSimplePriusCar()`. All the tests in `automotive_simulator_test.cc` have been replaced with a call to `AddLoadableAgent()`. However, there's still the python function `simulation_utils.py::build_simple_car_simulator()` that uses it. @basicNew , is this something that we want to preserve?