### PR TITLE
Use a drake binary in CI instead of compiling it from source

### DIFF
--- a/tools/continuous_integration/jenkins/build
+++ b/tools/continuous_integration/jenkins/build
@@ -7,15 +7,54 @@ COMPILER_PATH="/usr/bin/g++-5"
 
 mkdir -p install
 
-# The date that conforms part of the build URL is automatically parsed from the 
+# The date that forms part of the build URL is automatically parsed from the
 # drake respository's last commit date, avoiding us from doing it by hand.
+
 pushd workspace/drake
 COMMIT_DATE="$(git log -n 1 --pretty='format:%cd' --date=format:'%Y%m%d')"
 popd
-BUILD_URL="https://drake-packages.csail.mit.edu/drake/nightly/drake-$COMMIT_DATE-xenial.tar.gz"
+
+BINARY_URL="https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-xenial.tar.gz"
+
+VALID_URL=false
+
+url_exists () {
+    echo Testing URL: $1
+    # Sends an http request against the test URL, will return false if whether the
+    # request specifically fails or if it takes more than 5 seconds to respond.
+    if curl --output /dev/null --silent --head --max-time 5 --fail "$1"; then
+        VALID_URL=true
+    fi
+}
+
+TEST_URL="${BINARY_URL//YYYYMMDD/$COMMIT_DATE}"
+url_exists $TEST_URL
+
+# In case the initial URL for downloading the binary is not valid,
+# the script will attempt to generate new ones based on the dates of up
+# to 5 days after the commit date.
+if ! $VALID_URL; then
+    TEST_DATE=$COMMIT_DATE
+    NUM_ATTEMPTS=1
+    while ! $VALID_URL; do
+      if [ "$NUM_ATTEMPTS" -le "5" ] ; then
+        # Adds one day to the current date to test.
+        TEST_DATE=$(date +%Y%m%d -d "$TEST_DATE + 1 day")
+        # Updates binary's URL with new date.
+        TEST_URL="${BINARY_URL//YYYYMMDD/$TEST_DATE}"
+        # Checks availability.
+        url_exists $TEST_URL
+        NUM_ATTEMPTS=$((NUM_ATTEMPTS+1))
+      # If couldn't find a valid URL between the tested dates, fails.
+      else
+        echo "ERROR: Couldn't find a valid URL to download drake binaries."
+        exit 1
+      fi
+    done
+fi
 
 # Downloads drake binary and untars it into the install directory.
-wget -qO- $BUILD_URL | tar xvz -C `pwd`/install --strip 1
+curl $TEST_URL | tar xvz -C `pwd`/install --strip 1
 
 mkdir -p build
 

--- a/tools/continuous_integration/jenkins/setup_early
+++ b/tools/continuous_integration/jenkins/setup_early
@@ -16,11 +16,11 @@ sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C
 sudo apt-get update -qq
 sudo apt-get install -y --no-install-recommends $(tr '\n' ' ' <<EOF
 awscli
+curl
 git
 libignition-cmake-dev
 mercurial
 pkg-config
 python3-vcstool
-wget
 EOF
 )


### PR DESCRIPTION
Fixes #352 , which is also reflected on the 5th element of the list on #378 .
- Avoids the compilation step we used to have for drake in CI and instead, downloads a binary correspondent to the hash we are pointing in the `delphyne.repos` file.
    - This URL has to be manually updated every time we update that hash.
- Adds `wget` as a dependency.

Obs: cloning the drake repository is still required here, because although it's not built from source anymore, it's still required to run the `install_prereqs.sh` script to solve drake's runtime dependencies.

With this upgrade the time required for the `build` step goes down from 16:26 minutes to 2:31 minutes :)
![screenshot from 2018-05-09 17-04-45](https://user-images.githubusercontent.com/5348967/39837780-d107d048-53ad-11e8-9463-2222498c02ce.png)
![screenshot from 2018-05-09 17-04-18](https://user-images.githubusercontent.com/5348967/39837784-d3a8f41c-53ad-11e8-8bef-42262f621f02.png)