### PR TITLE
Generic python parameters for agents

### DIFF
--- a/backend/automotive_simulator.h
+++ b/backend/automotive_simulator.h
@@ -95,11 +95,37 @@ class AutomotiveSimulator {
       const drake::maliput::api::RoadGeometry* road,
       std::unique_ptr<AgentPluginParams> parameters);
 
-  /// A handy overload in case the plugin doesn't require any extra parameters.
+  /// An handy overload for the case that the plugin doesn't require any extra
+  /// parameters.
   int AddLoadableAgent(
       const std::string& plugin_library_name, const std::string& agent_name,
       std::unique_ptr<drake::systems::BasicVector<T>> initial_state,
       const drake::maliput::api::RoadGeometry* road);
+
+  /// Adds a Vehicle to this simulation from a loadable module.
+  ///
+  /// *Important*: This overloaded version of the method is intended to be used
+  /// by the python-binding machinery. Developers should use the
+  /// AddLoadableAgent methods as defined above, as those provide safe memory
+  /// management to the agent parameters.
+  int AddLoadableAgent(
+      const std::string& plugin_library_name, const std::string& plugin_name,
+      const std::string& agent_name,
+      std::unique_ptr<drake::systems::BasicVector<T>> initial_state,
+      const drake::maliput::api::RoadGeometry* road,
+      const PythonAgentPluginParams* python_parameters);
+
+  /// Adds a Vehicle to this simulation from a loadable module.
+  ///
+  /// *Important*: This overloaded version of the method is intended to be used
+  /// by the python-binding machinery. Developers should use the
+  /// AddLoadableAgent methods as defined above, as those provide safe memory
+  /// management to the agent parameters.
+  int AddLoadableAgent(
+      const std::string& plugin_library_name, const std::string& agent_name,
+      std::unique_ptr<drake::systems::BasicVector<T>> initial_state,
+      const drake::maliput::api::RoadGeometry* road,
+      const PythonAgentPluginParams* python_parameters);
 
   /// Sets the RoadGeometry for this simulation.
   ///
@@ -173,6 +199,11 @@ class AutomotiveSimulator {
   // The rate at which the scene is published over ign-transport to update the
   // scene tree widget tree.
   const double kScenePublishPeriodMs = 250.0;
+
+  // Loads an agent given a library name. If there are more than one agent in
+  // the library, the plugin name has to be specified.
+  std::unique_ptr<delphyne::AgentPluginBase<T>> LoadAgentPlugin(
+      const std::string& plugin_library_name, const std::string& plugin_name);
 
   // Verifies that the provided `name` of an agent is unique among all agents
   // that have been added to the `AutomotiveSimulator`. Throws a

--- a/include/delphyne/CMakeLists.txt
+++ b/include/delphyne/CMakeLists.txt
@@ -5,5 +5,6 @@
 delphyne_install_includes(
   ${PROJECT_NAME}${PROJECT_MAJOR_VERSION}/${PROJECT_NAME}/
   agent_plugin_base.h
+  linb-any
   types.h
 )

--- a/include/delphyne/linb-any
+++ b/include/delphyne/linb-any
@@ -1,0 +1,466 @@
+// https://raw.githubusercontent.com/thelink2012/any/master/any.hpp  -*- C++ -*-
+//
+// clalancette: the version of std::any in gcc-5 on Ubuntu 16.04 is buggy
+// and doesn't work in all of the situations we need it to.  This is a drop-in
+// replacement for std::any which actually works.  Once we have upgraded to
+// new enough compilers, this can probably be dropped.  Note that I have kept
+// the code as-is from the URL above, so the namespace and style is different
+// from the rest of the delphyne codebase.
+//
+// Implementation of N4562 std::experimental::any (merged into C++17) for C++11 compilers.
+//
+// See also:
+//   + http://en.cppreference.com/w/cpp/any
+//   + http://en.cppreference.com/w/cpp/experimental/any
+//   + http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4562.html#any
+//   + https://cplusplus.github.io/LWG/lwg-active.html#2509
+//
+//
+// Copyright (c) 2016 Denilson das Mercês Amorim
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+#ifndef LINB_ANY_HPP
+#define LINB_ANY_HPP
+#pragma once
+#include <typeinfo>
+#include <type_traits>
+#include <stdexcept>
+
+namespace linb
+{
+
+class bad_any_cast : public std::bad_cast
+{
+public:
+    const char* what() const noexcept override
+    {
+        return "bad any cast";
+    }
+};
+
+class any final
+{
+public:
+    /// Constructs an object of type any with an empty state.
+    any() :
+        vtable(nullptr)
+    {
+    }
+
+    /// Constructs an object of type any with an equivalent state as other.
+    any(const any& rhs) :
+        vtable(rhs.vtable)
+    {
+        if(!rhs.empty())
+        {
+            rhs.vtable->copy(rhs.storage, this->storage);
+        }
+    }
+
+    /// Constructs an object of type any with a state equivalent to the original state of other.
+    /// rhs is left in a valid but otherwise unspecified state.
+    any(any&& rhs) noexcept :
+        vtable(rhs.vtable)
+    {
+        if(!rhs.empty())
+        {
+            rhs.vtable->move(rhs.storage, this->storage);
+            rhs.vtable = nullptr;
+        }
+    }
+
+    /// Same effect as this->clear().
+    ~any()
+    {
+        this->clear();
+    }
+
+    /// Constructs an object of type any that contains an object of type T direct-initialized with std::forward<ValueType>(value).
+    ///
+    /// T shall satisfy the CopyConstructible requirements, otherwise the program is ill-formed.
+    /// This is because an `any` may be copy constructed into another `any` at any time, so a copy should always be allowed.
+    template<typename ValueType, typename = typename std::enable_if<!std::is_same<typename std::decay<ValueType>::type, any>::value>::type>
+    any(ValueType&& value)
+    {
+        static_assert(std::is_copy_constructible<typename std::decay<ValueType>::type>::value,
+            "T shall satisfy the CopyConstructible requirements.");
+        this->construct(std::forward<ValueType>(value));
+    }
+
+    /// Has the same effect as any(rhs).swap(*this). No effects if an exception is thrown.
+    any& operator=(const any& rhs)
+    {
+        any(rhs).swap(*this);
+        return *this;
+    }
+
+    /// Has the same effect as any(std::move(rhs)).swap(*this).
+    ///
+    /// The state of *this is equivalent to the original state of rhs and rhs is left in a valid
+    /// but otherwise unspecified state.
+    any& operator=(any&& rhs) noexcept
+    {
+        any(std::move(rhs)).swap(*this);
+        return *this;
+    }
+
+    /// Has the same effect as any(std::forward<ValueType>(value)).swap(*this). No effect if a exception is thrown.
+    ///
+    /// T shall satisfy the CopyConstructible requirements, otherwise the program is ill-formed.
+    /// This is because an `any` may be copy constructed into another `any` at any time, so a copy should always be allowed.
+    template<typename ValueType, typename = typename std::enable_if<!std::is_same<typename std::decay<ValueType>::type, any>::value>::type>
+    any& operator=(ValueType&& value)
+    {
+        static_assert(std::is_copy_constructible<typename std::decay<ValueType>::type>::value,
+            "T shall satisfy the CopyConstructible requirements.");
+        any(std::forward<ValueType>(value)).swap(*this);
+        return *this;
+    }
+
+    /// If not empty, destroys the contained object.
+    void clear() noexcept
+    {
+        if(!empty())
+        {
+            this->vtable->destroy(storage);
+            this->vtable = nullptr;
+        }
+    }
+
+    /// Returns true if *this has no contained object, otherwise false.
+    bool empty() const noexcept
+    {
+        return this->vtable == nullptr;
+    }
+
+    /// If *this has a contained object of type T, typeid(T); otherwise typeid(void).
+    const std::type_info& type() const noexcept
+    {
+        return empty()? typeid(void) : this->vtable->type();
+    }
+
+    /// Exchange the states of *this and rhs.
+    void swap(any& rhs) noexcept
+    {
+        if(this->vtable != rhs.vtable)
+        {
+            any tmp(std::move(rhs));
+
+            // move from *this to rhs.
+            rhs.vtable = this->vtable;
+            if(this->vtable != nullptr)
+            {
+                this->vtable->move(this->storage, rhs.storage);
+                //this->vtable = nullptr; -- uneeded, see below
+            }
+
+            // move from tmp (previously rhs) to *this.
+            this->vtable = tmp.vtable;
+            if(tmp.vtable != nullptr)
+            {
+                tmp.vtable->move(tmp.storage, this->storage);
+                tmp.vtable = nullptr;
+            }
+        }
+        else // same types
+        {
+            if(this->vtable != nullptr)
+                this->vtable->swap(this->storage, rhs.storage);
+        }
+    }
+
+private: // Storage and Virtual Method Table
+
+    union storage_union
+    {
+        using stack_storage_t = typename std::aligned_storage<2 * sizeof(void*), std::alignment_of<void*>::value>::type;
+
+        void*               dynamic;
+        stack_storage_t     stack;      // 2 words for e.g. shared_ptr
+    };
+
+    /// Base VTable specification.
+    struct vtable_type
+    {
+        // Note: The caller is responssible for doing .vtable = nullptr after destructful operations
+        // such as destroy() and/or move().
+
+        /// The type of the object this vtable is for.
+        const std::type_info& (*type)() noexcept;
+
+        /// Destroys the object in the union.
+        /// The state of the union after this call is unspecified, caller must ensure not to use src anymore.
+        void(*destroy)(storage_union&) noexcept;
+
+        /// Copies the **inner** content of the src union into the yet unitialized dest union.
+        /// As such, both inner objects will have the same state, but on separate memory locations.
+        void(*copy)(const storage_union& src, storage_union& dest);
+
+        /// Moves the storage from src to the yet unitialized dest union.
+        /// The state of src after this call is unspecified, caller must ensure not to use src anymore.
+        void(*move)(storage_union& src, storage_union& dest) noexcept;
+
+        /// Exchanges the storage between lhs and rhs.
+        void(*swap)(storage_union& lhs, storage_union& rhs) noexcept;
+    };
+
+    /// VTable for dynamically allocated storage.
+    template<typename T>
+    struct vtable_dynamic
+    {
+        static const std::type_info& type() noexcept
+        {
+            return typeid(T);
+        }
+
+        static void destroy(storage_union& storage) noexcept
+        {
+            //assert(reinterpret_cast<T*>(storage.dynamic));
+            delete reinterpret_cast<T*>(storage.dynamic);
+        }
+
+        static void copy(const storage_union& src, storage_union& dest)
+        {
+            dest.dynamic = new T(*reinterpret_cast<const T*>(src.dynamic));
+        }
+
+        static void move(storage_union& src, storage_union& dest) noexcept
+        {
+            dest.dynamic = src.dynamic;
+            src.dynamic = nullptr;
+        }
+
+        static void swap(storage_union& lhs, storage_union& rhs) noexcept
+        {
+            // just exchage the storage pointers.
+            std::swap(lhs.dynamic, rhs.dynamic);
+        }
+    };
+
+    /// VTable for stack allocated storage.
+    template<typename T>
+    struct vtable_stack
+    {
+        static const std::type_info& type() noexcept
+        {
+            return typeid(T);
+        }
+
+        static void destroy(storage_union& storage) noexcept
+        {
+            reinterpret_cast<T*>(&storage.stack)->~T();
+        }
+
+        static void copy(const storage_union& src, storage_union& dest)
+        {
+            new (&dest.stack) T(reinterpret_cast<const T&>(src.stack));
+        }
+
+        static void move(storage_union& src, storage_union& dest) noexcept
+        {
+            // one of the conditions for using vtable_stack is a nothrow move constructor,
+            // so this move constructor will never throw a exception.
+            new (&dest.stack) T(std::move(reinterpret_cast<T&>(src.stack)));
+            destroy(src);
+        }
+
+        static void swap(storage_union& lhs, storage_union& rhs) noexcept
+        {
+            std::swap(reinterpret_cast<T&>(lhs.stack), reinterpret_cast<T&>(rhs.stack));
+        }
+    };
+
+    /// Whether the type T must be dynamically allocated or can be stored on the stack.
+    template<typename T>
+    struct requires_allocation :
+        std::integral_constant<bool,
+                !(std::is_nothrow_move_constructible<T>::value      // N4562 �6.3/3 [any.class]
+                  && sizeof(T) <= sizeof(storage_union::stack)
+                  && std::alignment_of<T>::value <= std::alignment_of<storage_union::stack_storage_t>::value)>
+    {};
+
+    /// Returns the pointer to the vtable of the type T.
+    template<typename T>
+    static vtable_type* vtable_for_type()
+    {
+        using VTableType = typename std::conditional<requires_allocation<T>::value, vtable_dynamic<T>, vtable_stack<T>>::type;
+        static vtable_type table = {
+            VTableType::type, VTableType::destroy,
+            VTableType::copy, VTableType::move,
+            VTableType::swap,
+        };
+        return &table;
+    }
+
+protected:
+    template<typename T>
+    friend const T* any_cast(const any* operand) noexcept;
+    template<typename T>
+    friend T* any_cast(any* operand) noexcept;
+
+    /// Same effect as is_same(this->type(), t);
+    bool is_typed(const std::type_info& t) const
+    {
+        return is_same(this->type(), t);
+    }
+
+    /// Checks if two type infos are the same.
+    ///
+    /// If ANY_IMPL_FAST_TYPE_INFO_COMPARE is defined, checks only the address of the
+    /// type infos, otherwise does an actual comparision. Checking addresses is
+    /// only a valid approach when there's no interaction with outside sources
+    /// (other shared libraries and such).
+    static bool is_same(const std::type_info& a, const std::type_info& b)
+    {
+#ifdef ANY_IMPL_FAST_TYPE_INFO_COMPARE
+        return &a == &b;
+#else
+        return a == b;
+#endif
+    }
+
+    /// Casts (with no type_info checks) the storage pointer as const T*.
+    template<typename T>
+    const T* cast() const noexcept
+    {
+        return requires_allocation<typename std::decay<T>::type>::value?
+            reinterpret_cast<const T*>(storage.dynamic) :
+            reinterpret_cast<const T*>(&storage.stack);
+    }
+
+    /// Casts (with no type_info checks) the storage pointer as T*.
+    template<typename T>
+    T* cast() noexcept
+    {
+        return requires_allocation<typename std::decay<T>::type>::value?
+            reinterpret_cast<T*>(storage.dynamic) :
+            reinterpret_cast<T*>(&storage.stack);
+    }
+
+private:
+    storage_union storage; // on offset(0) so no padding for align
+    vtable_type*  vtable;
+
+    template<typename ValueType, typename T>
+    typename std::enable_if<requires_allocation<T>::value>::type
+    do_construct(ValueType&& value)
+    {
+        storage.dynamic = new T(std::forward<ValueType>(value));
+    }
+
+    template<typename ValueType, typename T>
+    typename std::enable_if<!requires_allocation<T>::value>::type
+    do_construct(ValueType&& value)
+    {
+        new (&storage.stack) T(std::forward<ValueType>(value));
+    }
+
+    /// Chooses between stack and dynamic allocation for the type decay_t<ValueType>,
+    /// assigns the correct vtable, and constructs the object on our storage.
+    template<typename ValueType>
+    void construct(ValueType&& value)
+    {
+        using T = typename std::decay<ValueType>::type;
+
+        this->vtable = vtable_for_type<T>();
+
+        do_construct<ValueType,T>(std::forward<ValueType>(value));
+    }
+};
+
+
+
+namespace detail
+{
+    template<typename ValueType>
+    inline ValueType any_cast_move_if_true(typename std::remove_reference<ValueType>::type* p, std::true_type)
+    {
+        return std::move(*p);
+    }
+
+    template<typename ValueType>
+    inline ValueType any_cast_move_if_true(typename std::remove_reference<ValueType>::type* p, std::false_type)
+    {
+        return *p;
+    }
+}
+
+/// Performs *any_cast<add_const_t<remove_reference_t<ValueType>>>(&operand), or throws bad_any_cast on failure.
+template<typename ValueType>
+inline ValueType any_cast(const any& operand)
+{
+    auto p = any_cast<typename std::add_const<typename std::remove_reference<ValueType>::type>::type>(&operand);
+    if(p == nullptr) throw bad_any_cast();
+    return *p;
+}
+
+/// Performs *any_cast<remove_reference_t<ValueType>>(&operand), or throws bad_any_cast on failure.
+template<typename ValueType>
+inline ValueType any_cast(any& operand)
+{
+    auto p = any_cast<typename std::remove_reference<ValueType>::type>(&operand);
+    if(p == nullptr) throw bad_any_cast();
+    return *p;
+}
+
+///
+/// If ANY_IMPL_ANYCAST_MOVEABLE is not defined, does as N4562 specifies:
+///     Performs *any_cast<remove_reference_t<ValueType>>(&operand), or throws bad_any_cast on failure.
+///
+/// If ANY_IMPL_ANYCAST_MOVEABLE is defined, does as LWG Defect 2509 specifies:
+///     If ValueType is MoveConstructible and isn't a lvalue reference, performs
+///     std::move(*any_cast<remove_reference_t<ValueType>>(&operand)), otherwise
+///     *any_cast<remove_reference_t<ValueType>>(&operand). Throws bad_any_cast on failure.
+///
+template<typename ValueType>
+inline ValueType any_cast(any&& operand)
+{
+#ifdef ANY_IMPL_ANY_CAST_MOVEABLE
+    // https://cplusplus.github.io/LWG/lwg-active.html#2509
+    using can_move = std::integral_constant<bool,
+        std::is_move_constructible<ValueType>::value
+        && !std::is_lvalue_reference<ValueType>::value>;
+#else
+    using can_move = std::false_type;
+#endif
+
+    auto p = any_cast<typename std::remove_reference<ValueType>::type>(&operand);
+    if(p == nullptr) throw bad_any_cast();
+    return detail::any_cast_move_if_true<ValueType>(p, can_move());
+}
+
+/// If operand != nullptr && operand->type() == typeid(ValueType), a pointer to the object
+/// contained by operand, otherwise nullptr.
+template<typename T>
+inline const T* any_cast(const any* operand) noexcept
+{
+    if(operand == nullptr || !operand->is_typed(typeid(T)))
+        return nullptr;
+    else
+        return operand->cast<T>();
+}
+
+/// If operand != nullptr && operand->type() == typeid(ValueType), a pointer to the object
+/// contained by operand, otherwise nullptr.
+template<typename T>
+inline T* any_cast(any* operand) noexcept
+{
+    if(operand == nullptr || !operand->is_typed(typeid(T)))
+        return nullptr;
+    else
+        return operand->cast<T>();
+}
+
+}
+
+namespace std
+{
+    inline void swap(linb::any& lhs, linb::any& rhs) noexcept
+    {
+        lhs.swap(rhs);
+    }
+}
+
+#endif

--- a/python/delphyne/simulation_utils.py
+++ b/python/delphyne/simulation_utils.py
@@ -16,8 +16,7 @@ from delphyne.bindings import (
     AutomotiveSimulator,
     MaliputRailcarParams,
     MaliputRailcarState,
-    MobilCarAgentParams,
-    RailCarAgentParams
+    PythonAgentPluginParams,
 )
 from delphyne.launcher import Launcher
 from pydrake.automotive import (
@@ -126,7 +125,8 @@ def add_mobil_car(simulator, robot_id, road, position_x=0, position_y=0):
     mobil_car_state = SimpleCarState()
     mobil_car_state.set_x(position_x)
     mobil_car_state.set_y(position_y)
-    agent_params = MobilCarAgentParams(True)
+    agent_params = PythonAgentPluginParams()
+    agent_params.put("initial_with_s_", True)
     # Instantiates a Loadable MOBIL Car.
     simulator.AddLoadableAgent("mobil-car",
                                str(robot_id),
@@ -149,7 +149,9 @@ def add_maliput_railcar(simulator, robot_id, road, s_coordinate=0, speed=0):
     start_params = MaliputRailcarParams()
     start_params.r = 0
     start_params.h = 0
-    agent_params = RailCarAgentParams(lane_direction, start_params)
+    agent_params = PythonAgentPluginParams()
+    agent_params.put("lane_direction", lane_direction)
+    agent_params.put("start_params", start_params)
     simulator.AddLoadableAgent("rail-car",
                                str(robot_id),
                                railcar_state,

--- a/python/examples/railcar_in_multilane.py
+++ b/python/examples/railcar_in_multilane.py
@@ -17,7 +17,7 @@ from delphyne.bindings import (
     AutomotiveSimulator,
     MaliputRailcarState,
     MaliputRailcarParams,
-    RailCarAgentParams,
+    PythonAgentPluginParams,
     RoadBuilder,
     SimulatorRunner
 )
@@ -44,7 +44,9 @@ def setup_railcar(simulator, name, road, lane):
     start_params.r = 0
     start_params.h = 0
 
-    agent_params = RailCarAgentParams(lane_direction, start_params)
+    agent_params = PythonAgentPluginParams()
+    agent_params.put("lane_direction", lane_direction)
+    agent_params.put("start_params", start_params)
 
     simulator.AddLoadableAgent("rail-car",
                                name,

--- a/src/agents/mobil_car.cc
+++ b/src/agents/mobil_car.cc
@@ -36,6 +36,12 @@ class MobilCar final : public delphyne::AgentPlugin {
 
   MobilCar() : simple_car_() { igndbg << "MobilCar constructor" << std::endl; }
 
+  std::unique_ptr<AgentPluginParams> ParamsFromPython(
+      const PythonAgentPluginParams* python_parameters) override {
+    bool initial_with_s_ = python_parameters->at<bool>("initial_with_s_");
+    return std::make_unique<MobilCarAgentParams>(initial_with_s_);
+  }
+
   int Configure(const std::string& name, int id,
                 drake::systems::DiagramBuilder<double>* builder,
                 drake::systems::rendering::PoseAggregator<double>* aggregator,

--- a/src/agents/rail_car.cc
+++ b/src/agents/rail_car.cc
@@ -43,6 +43,23 @@ class RailCar final : public delphyne::AgentPlugin {
     igndbg << "RailCar constructor" << std::endl;
   }
 
+  std::unique_ptr<AgentPluginParams> ParamsFromPython(
+      const PythonAgentPluginParams* python_parameters) override {
+    auto lane_direction =
+        python_parameters->at<drake::automotive::LaneDirection*>(
+            "lane_direction");
+    auto lane_direction_ptr =
+        std::unique_ptr<drake::automotive::LaneDirection>(lane_direction);
+    auto start_params =
+        python_parameters->at<drake::automotive::MaliputRailcarParams<double>*>(
+            "start_params");
+    auto start_params_ptr =
+        std::unique_ptr<drake::automotive::MaliputRailcarParams<double>>(
+            start_params);
+    return std::make_unique<RailCarAgentParams>(std::move(lane_direction_ptr),
+                                                std::move(start_params_ptr));
+  }
+
   int Configure(const std::string& name, int id,
                 drake::systems::DiagramBuilder<double>* builder,
                 drake::systems::rendering::PoseAggregator<double>* aggregator,


### PR DESCRIPTION
With this PR a C++ agent developer doesn't need to create any python bindings to be able to script his/her agent from python. The typical would be:

- Create the agent class in C++ (e.g. `Agent1`)
- Create the agent parameter class in C++ (e.g. `Agent1Parameters` with `x` and `y` members)
- Write a function that converts from `PythonAgentPluginParams` to `Agent1Parameters`
- Use it from python like:

```
agent_params = PythonAgentPluginParams()
agent_params.put("x", some_object)
agent_params.put("y", other_object)
simulator.AddLoadableAgent("agent-1", id, state, road, agent_params)
```

Note: there are a bunch of things that can be improved here so that the programmer has to code a lot less. In particular points 2) and 3) could be using a macro that just takes the names of the fields and their types and derives both the parameter class and the conversion function. However, given that we may shift our focus to another approach I think it makes more sense to stop here and evaluate if we want to put more effort here.
