### PR TITLE
[infra] disable drake info level logging

### DIFF
--- a/src/backend/automotive_simulator.cc
+++ b/src/backend/automotive_simulator.cc
@@ -54,15 +54,14 @@ using drake::systems::SystemOutput;
 
 template <typename T>
 AutomotiveSimulator<T>::AutomotiveSimulator() {
-
-  // Avoid the many & varied 'info' level logging messages coming from drake.
-  //
-  // Note: Drake will have defined HAVE_SPDLOG if it is using that
-  // (see lib/cmake/spdlog/spdlog-config.cmake that was installed by drake).
-  //
-  // It would be preferable if drake did not spam downstream application
-  // development on info channels, but that will require a discussion and
-  // a large swipe at the many uses in drake.
+// Avoid the many & varied 'info' level logging messages coming from drake.
+//
+// Note: Drake will have defined HAVE_SPDLOG if it is using that
+// (see lib/cmake/spdlog/spdlog-config.cmake that was installed by drake).
+//
+// It would be preferable if drake did not spam downstream application
+// development on info channels, but that will require a discussion and
+// a large swipe at the many uses in drake.
 #ifdef HAVE_SPDLOG
   drake::log()->set_level(spdlog::level::warn);
 #endif


### PR DESCRIPTION
This winds back the level on drake logging. I would prefer that they had left the choice of what makes it to the screen to the application on top of drake, but that's a big change to ask and this will give us some sanity by stopping `sdf_parser` and `multibody` getting overly noisy.