### PR TITLE
Populates Scene messages with model name and pose

### DIFF
--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -63,6 +63,7 @@ install(TARGETS scene_system
 #
 add_library(automotive_simulator
   automotive_simulator.cc
+  ign_models_assembler.cc
   system.h
 )
 set_target_properties(automotive_simulator PROPERTIES OUTPUT_NAME ${PROJECT_NAME}-automotive-simulator)

--- a/src/backend/ign_models_assembler.cc
+++ b/src/backend/ign_models_assembler.cc
@@ -1,0 +1,67 @@
+// Copyright 2018 Toyota Research Institute
+
+#include "backend/ign_models_assembler.h"
+
+#include <map>
+
+#include <drake/common/eigen_types.h>
+#include <drake/systems/rendering/pose_bundle.h>
+
+namespace delphyne {
+
+IgnModelsAssembler::IgnModelsAssembler() {
+  models_input_port_index_ = DeclareAbstractInputPort().get_index();
+  states_input_port_index_ = DeclareAbstractInputPort().get_index();
+
+  DeclareAbstractOutputPort(&IgnModelsAssembler::CalcAssembledIgnModelVMessage);
+}
+
+void IgnModelsAssembler::CalcAssembledIgnModelVMessage(
+    const drake::systems::Context<double>& context,
+    ignition::msgs::Model_V* output_models) const {
+  // Ensures provided output models message is cleared.
+  output_models->Clear();
+
+  // Retrieves models and states inputs.
+  const ignition::msgs::Model_V& input_models =
+      EvalAbstractInput(context, models_input_port_index_)
+          ->template GetValue<ignition::msgs::Model_V>();
+
+  const drake::systems::rendering::PoseBundle<double>& input_states =
+      EvalAbstractInput(context, states_input_port_index_)
+          ->template GetValue<drake::systems::rendering::PoseBundle<double>>();
+
+  // Copies timestamp from input to output.
+  output_models->mutable_header()->mutable_stamp()->CopyFrom(
+      input_models.header().stamp());
+
+  // Reverses the pose bundle index to model ID mapping
+  // for convenience.
+  std::map<int, int> index_per_model_id;
+  for (int i = 0; i < input_states.get_num_poses(); ++i) {
+    const int id = input_states.get_model_instance_id(i);
+    index_per_model_id[id] = i;
+  }
+
+  // Iterates over input models, copying them over to the output while
+  // stamping the model based on the model ID to pose mapping.
+  for (const ignition::msgs::Model& input_model : input_models.models()) {
+    const int index = index_per_model_id[input_model.id()];
+    ignition::msgs::Model* output_model = output_models->add_models();
+    output_model->CopyFrom(input_model);
+    output_model->set_name(input_states.get_name(index));
+    ignition::msgs::Pose* ign_pose = output_model->mutable_pose();
+    const drake::Isometry3<double>& pose = input_states.get_pose(index);
+    const drake::Vector3<double>& position = pose.translation();
+    ign_pose->mutable_position()->set_x(position.x());
+    ign_pose->mutable_position()->set_y(position.y());
+    ign_pose->mutable_position()->set_z(position.z());
+    const drake::Quaternion<double> orientation(pose.linear());
+    ign_pose->mutable_orientation()->set_x(orientation.x());
+    ign_pose->mutable_orientation()->set_y(orientation.y());
+    ign_pose->mutable_orientation()->set_z(orientation.z());
+    ign_pose->mutable_orientation()->set_w(orientation.w());
+  }
+}
+
+}  // namespace delphyne

--- a/src/backend/ign_models_assembler.h
+++ b/src/backend/ign_models_assembler.h
@@ -1,0 +1,54 @@
+// Copyright 2018 Toyota Research Institute
+
+#pragma once
+
+#include <drake/systems/framework/leaf_system.h>
+
+#include <ignition/msgs.hh>
+
+namespace delphyne {
+
+/// A helper System to assemble ignition::msgs::Model messages (given
+/// as an ignition::msgs::Model_V message i.e. a collection of them)
+/// using externally provided details like name and pose.
+///
+/// Besides the base ignition::msgs::Model_V input port, a
+/// drake::systems::rendering::PoseBundle<double> input port provides
+/// poses and names.
+class IgnModelsAssembler : public drake::systems::LeafSystem<double> {
+ public:
+  IgnModelsAssembler();
+
+  /// Returns the input descriptor for models. This port expects an
+  /// ignition::msgs::Model_V message, containing the models to be assembled.
+  const drake::systems::InputPortDescriptor<double>& get_models_input_port()
+      const {
+    return get_input_port(models_input_port_index_);
+  }
+
+  int get_models_input_port_index() const { return models_input_port_index_; }
+
+  /// Returns the input port descriptor for model states. This port expects a
+  /// drake::systems::rendering::PoseBundle<double>, containing all models
+  /// states.
+  const drake::systems::InputPortDescriptor<double>& get_states_input_port()
+      const {
+    return get_input_port(states_input_port_index_);
+  }
+
+  int get_states_input_port_index() const { return states_input_port_index_; }
+
+ private:
+  // Calculates (i.e. assembles) an output model vector message
+  // based on the input model vector and model states.
+  void CalcAssembledIgnModelVMessage(
+      const drake::systems::Context<double>& context,
+      ignition::msgs::Model_V* output_models) const;
+
+  // The index of the models' abstract input port.
+  int models_input_port_index_;
+  // The index of the states' abstract input port.
+  int states_input_port_index_;
+};
+
+}  // namespace delphyne

--- a/src/backend/scene_system.cc
+++ b/src/backend/scene_system.cc
@@ -67,6 +67,10 @@ void SceneSystem::CalcSceneMessage(
       continue;
     }
 
+    // Updates the model itself.
+    matching_scene_model->set_name(updated_pose_model.name());
+    matching_scene_model->mutable_pose()->CopyFrom(updated_pose_model.pose());
+
     // Updates each model link.
     for (const ignition::msgs::Link& updated_pose_link :
          updated_pose_model.link()) {

--- a/test/regression/cpp/CMakeLists.txt
+++ b/test/regression/cpp/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SOURCES
   drake_simple_car_state_to_ign_translator_system_test.cc
   ign_driving_command_to_drake_translator_system_test.cc
   ign_model_v_to_lcm_viewer_draw_translator_system_test.cc
+  ign_models_assembler_test.cc
   ign_publisher_system_test.cc
   ign_simple_car_state_to_drake_translator_system_test.cc
   ign_subscriber_system_test.cc

--- a/test/regression/cpp/helpers.cc
+++ b/test/regression/cpp/helpers.cc
@@ -6,6 +6,9 @@
 #include <string>
 #include <vector>
 
+#include <drake/common/eigen_types.h>
+#include <drake/systems/rendering/pose_bundle.h>
+
 #include "backend/system.h"
 #include "drake/lcmt_viewer_draw.hpp"
 #include "drake/lcmt_viewer_geometry_data.hpp"
@@ -130,6 +133,21 @@ ignition::msgs::Model_V BuildPreloadedModelVMsg() {
   for (int i = 0; i < kPreloadedModels; ++i) {
     ::ignition::msgs::Model* model = robot_models.add_models();
     model->set_id(i);
+    model->set_name("none");
+
+    ::ignition::msgs::Pose* model_pose = model->mutable_pose();
+
+    ::ignition::msgs::Vector3d* model_position = model_pose->mutable_position();
+    model_position->set_x(i);
+    model_position->set_y(i + 5.0);
+    model_position->set_z(i + 10.0);
+
+    ::ignition::msgs::Quaternion* model_orientation =
+        model_pose->mutable_orientation();
+    model_orientation->set_w(i);
+    model_orientation->set_x(i + 5.0);
+    model_orientation->set_y(i + 10.0);
+    model_orientation->set_z(i + 15.0);
 
     for (int j = 0; j < kPreloadedLinks; ++j) {
       ::ignition::msgs::Link* link = model->add_link();
@@ -151,6 +169,25 @@ ignition::msgs::Model_V BuildPreloadedModelVMsg() {
   }
 
   return robot_models;
+}
+
+using drake::Vector3;
+using drake::Isometry3;
+using drake::Translation3;
+using drake::AngleAxis;
+using drake::systems::rendering::PoseBundle;
+
+PoseBundle<double> BuildPreloadedPoseBundle() {
+  PoseBundle<double> model_states(kPreloadedModels);
+  for (int i = 0; i < kPreloadedModels; ++i) {
+    model_states.set_model_instance_id(i, i);
+    model_states.set_name(i, std::string("model") + std::to_string(i));
+    Isometry3<double> model_pose =
+        AngleAxis<double>(i, Vector3<double>::UnitZ()) *
+        Translation3<double>(i, i, i);
+    model_states.set_pose(i, model_pose);
+  }
+  return model_states;
 }
 
 ::testing::AssertionResult CheckLcmArrayToVector3dEquivalence(

--- a/test/regression/cpp/helpers.h
+++ b/test/regression/cpp/helpers.h
@@ -2,8 +2,9 @@
 
 #pragma once
 
-#include "drake/lcmt_viewer_draw.hpp"
-#include "drake/lcmt_viewer_load_robot.hpp"
+#include <drake/lcmt_viewer_draw.hpp>
+#include <drake/lcmt_viewer_load_robot.hpp>
+#include <drake/systems/rendering/pose_bundle.h>
 
 #include "gtest/gtest.h"
 
@@ -28,6 +29,12 @@ drake::lcmt_viewer_load_robot BuildPreloadedLoadRobotMsg();
 //
 // @return a loaded Model_V message.
 ignition::msgs::Model_V BuildPreloadedModelVMsg();
+
+// Generates a pre-loaded pose bundle with model poses
+// (@see BuildPreloadedModelVMsg).
+//
+// @return a drake::systems::rendering::PoseBundle<double> instance.
+drake::systems::rendering::PoseBundle<double> BuildPreloadedPoseBundle();
 
 // Asserts that all the array-iterable values from
 // lcm_msg match the content of the ign_models object.

--- a/test/regression/cpp/ign_models_assembler_test.cc
+++ b/test/regression/cpp/ign_models_assembler_test.cc
@@ -1,0 +1,108 @@
+// Copyright 2018 Toyota Research Institute
+
+#include "backend/ign_models_assembler.h"
+
+#include <algorithm>
+#include <chrono>
+#include <thread>
+
+#include <drake/common/eigen_types.h>
+#include <drake/systems/framework/framework_common.h>
+#include <drake/systems/rendering/pose_bundle.h>
+
+#include <gtest/gtest.h>
+
+#include "helpers.h"
+
+namespace delphyne {
+namespace {
+
+using drake::Vector3;
+using drake::Isometry3;
+using drake::Translation3;
+using drake::AngleAxis;
+using drake::systems::rendering::PoseBundle;
+
+// Checks that the ignition::msgs::Model_V assembly process works as expected.
+GTEST_TEST(IgnModelsAssemblerTest, CalcAssembledModelVTest) {
+  const ignition::msgs::Model_V input_models{test::BuildPreloadedModelVMsg()};
+
+  const PoseBundle<double> input_states{test::BuildPreloadedPoseBundle()};
+
+  IgnModelsAssembler models_assembler;
+  std::unique_ptr<drake::systems::Context<double>> context =
+      models_assembler.AllocateContext();
+
+  context->FixInputPort(models_assembler.get_models_input_port_index(),
+                        drake::systems::AbstractValue::Make(input_models));
+
+  context->FixInputPort(models_assembler.get_states_input_port_index(),
+                        drake::systems::AbstractValue::Make(input_states));
+
+  std::unique_ptr<drake::systems::SystemOutput<double>> output =
+      models_assembler.AllocateOutput(*context);
+  models_assembler.CalcOutput(*context, output.get());
+
+  const double kOutputPortIndex{0};
+  const auto& output_models =
+      output->get_data(kOutputPortIndex)->GetValue<ignition::msgs::Model_V>();
+
+  EXPECT_EQ(input_models.models_size(), output_models.models_size());
+
+  for (int i = 0; i < output_models.models_size(); ++i) {
+    // Output models should match input models but on
+    // model name and pose.
+    EXPECT_TRUE(test::CheckProtobufMsgEquality(
+        input_models.models(i).header(), output_models.models(i).header()));
+    EXPECT_NE(input_models.models(i).name(), output_models.models(i).name());
+    EXPECT_EQ(input_models.models(i).id(), output_models.models(i).id());
+    EXPECT_EQ(input_models.models(i).is_static(),
+              output_models.models(i).is_static());
+    EXPECT_FALSE(test::CheckProtobufMsgEquality(
+        input_models.models(i).pose(), output_models.models(i).pose()));
+    ASSERT_EQ(input_models.models(i).joint().size(),
+              output_models.models(i).joint().size());
+    for (int j = 0; j < input_models.models(i).joint().size(); ++j) {
+      EXPECT_TRUE(test::CheckProtobufMsgEquality(
+          input_models.models(i).joint(j), output_models.models(i).joint(j)));
+    }
+    ASSERT_EQ(input_models.models(i).link().size(),
+              output_models.models(i).link().size());
+    for (int j = 0; j < input_models.models(i).link().size(); ++j) {
+      EXPECT_TRUE(test::CheckProtobufMsgEquality(
+          input_models.models(i).link(j), output_models.models(i).link(j)));
+    }
+    EXPECT_EQ(input_models.models(i).deleted(),
+              output_models.models(i).deleted());
+    ASSERT_EQ(input_models.models(i).visual().size(),
+              output_models.models(i).visual().size());
+    for (int j = 0; j < input_models.models(i).visual().size(); ++j) {
+      EXPECT_TRUE(test::CheckProtobufMsgEquality(
+          input_models.models(i).visual(j), output_models.models(i).visual(j)));
+    }
+    EXPECT_TRUE(test::CheckProtobufMsgEquality(
+        input_models.models(i).scale(), output_models.models(i).scale()));
+    EXPECT_EQ(input_models.models(i).self_collide(),
+              output_models.models(i).self_collide());
+
+    // Output model name should match that in input states.
+    EXPECT_EQ(output_models.models(i).name(), input_states.get_name(i));
+
+    // Output model pose should match that in input states.
+    const ignition::msgs::Pose& output_model_pose =
+        output_models.models(i).pose();
+    const Isometry3<double>& pose = input_states.get_pose(i);
+    const drake::Vector3<double>& position = pose.translation();
+    EXPECT_EQ(position.x(), output_model_pose.position().x());
+    EXPECT_EQ(position.y(), output_model_pose.position().y());
+    EXPECT_EQ(position.z(), output_model_pose.position().z());
+    const drake::Quaternion<double> orientation(pose.linear());
+    EXPECT_EQ(orientation.x(), output_model_pose.orientation().x());
+    EXPECT_EQ(orientation.y(), output_model_pose.orientation().y());
+    EXPECT_EQ(orientation.z(), output_model_pose.orientation().z());
+    EXPECT_EQ(orientation.w(), output_model_pose.orientation().w());
+  }
+}
+
+}  // namespace
+}  // namespace delphyne


### PR DESCRIPTION
Closes #423. This pull request introduces yet another system to assemble the car name and pose with the `ignition::msgs::Model` messages translated from LCM types, and tweaks the `SceneSystem` class to propagate these fields.

![delphyne_vis](https://user-images.githubusercontent.com/13500507/41061229-488bf814-69a8-11e8-81b5-7aba0d8e8d23.png)

Note that the name being a number is correct, as that's the naming pattern being used in our examples (e.g. check the `car_id` usage in [`delphyne-dragway`](https://github.com/ToyotaResearchInstitute/delphyne/blob/hidmic/publish_model_data/python/examples/delphyne-dragway#L59)).

BTW I'm open to suggestions w.r.t. naming :).