### PR TITLE
Added basic collision detection support to Delphyne.

### DIFF
--- a/python/delphyne/demos/CMakeLists.txt
+++ b/python/delphyne/demos/CMakeLists.txt
@@ -5,6 +5,7 @@
 install(
   FILES
     __init__.py
+    crash.py
     dragway.py
     helpers.py
     gazoo.py

--- a/python/delphyne/demos/crash.py
+++ b/python/delphyne/demos/crash.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python2.7
+#
+# Copyright 2018 Toyota Research Institute
+#
+"""
+The crash demo.
+"""
+##############################################################################
+# Imports
+##############################################################################
+
+from __future__ import print_function
+
+import math
+
+from delphyne.agents import SimpleCar
+from delphyne.simulation import (
+    AutomotiveSimulator,
+    SimulatorRunner
+)
+from delphyne.utilities import (
+    launch_interactive_simulation
+)
+
+from . import helpers
+
+##############################################################################
+# Supporting Classes & Methods
+##############################################################################
+
+
+def parse_arguments():
+    """Argument passing and demo documentation."""
+    parser = helpers.create_argument_parser(
+        "Car Crash!",
+        """
+An example that exercises collision detection by setting up multiple cars
+in collision course.
+        """
+    )
+    return parser.parse_args()
+
+
+def check_for_collisions(runner, simulator):
+    """
+    Checks for collisions between agents in simulation,
+    stopping the runner if *any* collision is detected.
+    :param runner: Current simulation runner.
+    :type runner: delphyne.simulation.SimulationRunner
+    :param simulator: Current simulator.
+    :type simulator: delphyne.simulation.AutomotiveSimulator
+    """
+    collisions = simulator.get_collisions()
+    if any(collisions):
+        print("Collision detected between the following car IDs:")
+        for pair in collisions:
+            print(pair)
+        print("Simulation stopped.")
+        runner.stop()
+
+
+##############################################################################
+# Main
+##############################################################################
+
+
+def main():
+    """Keeping pylint entertained."""
+    args = parse_arguments()
+
+    simulator = AutomotiveSimulator()
+
+    agent = SimpleCar(
+        name="racer0",
+        x=0.0,  # scene x-coordinate (m)
+        y=-50.0,  # scene y-coordinate (m)
+        heading=math.pi/2,    # heading (radians)
+        speed=5.0)     # speed in the direction of travel (m/s)
+    simulator.add_agent(agent)
+
+    agent = SimpleCar(
+        name="racer1",
+        x=-50.0,  # scene x-coordinate (m)
+        y=0.0,     # scene y-coordinate (m)
+        heading=0.0,    # heading (radians)
+        speed=5.1)     # speed in the direction of travel (m/s)
+    simulator.add_agent(agent)
+
+    agent = SimpleCar(
+        name="racer2",
+        x=0.0,  # scene x-coordinate (m)
+        y=50.0,  # scene y-coordinate (m)
+        heading=-math.pi/2,    # heading (radians)
+        speed=5.0)     # speed in the direction of travel (m/s)
+    simulator.add_agent(agent)
+
+    agent = SimpleCar(
+        name="racer3",
+        x=50.0,  # scene x-coordinate (m)
+        y=0.0,     # scene y-coordinate (m)
+        heading=math.pi,    # heading (radians)
+        speed=5.1)     # speed in the direction of travel (m/s)
+    simulator.add_agent(agent)
+
+    runner = SimulatorRunner(simulator,
+                             time_step=0.001,  # (secs)
+                             realtime_rate=args.realtime_rate,
+                             paused=args.paused)
+
+    with launch_interactive_simulation(runner):
+        # Adds a callback to check for agent collisions.
+        runner.add_step_callback(
+            lambda: check_for_collisions(runner, simulator)
+        )
+
+        runner.start()

--- a/python/delphyne/demos/helpers.py
+++ b/python/delphyne/demos/helpers.py
@@ -85,8 +85,8 @@ def create_argparse_epilog():
     """
     Create a humourous anecdote for argparse's epilog.
     """
+    msg = "And his noodly appendage reached forth to "\
+          "tickle the blessed...\n"
     if console.HAS_COLOURS:
-        msg = "And his noodly appendage reached forth to "\
-              "tickle the blessed...\n"
         return console.CYAN + msg + console.RESET
     return None

--- a/python/delphyne/simulation.cc
+++ b/python/delphyne/simulation.cc
@@ -93,6 +93,7 @@ PYBIND11_MODULE(simulation, m) {
       .def(py::init(
           [](void) { return std::make_unique<AutomotiveSimulator<double>>(); }))
       .def("add_agent", &AutomotiveSimulator<double>::AddAgent)
+      .def("get_collisions", &AutomotiveSimulator<double>::GetCollisions)
       .def("start", &AutomotiveSimulator<double>::Start)
       .def("set_road_geometry", &AutomotiveSimulator<double>::SetRoadGeometry,
            "Transfer a road geometry to the control of the simulator",

--- a/python/examples/CMakeLists.txt
+++ b/python/examples/CMakeLists.txt
@@ -7,6 +7,7 @@
 
 install(
   PROGRAMS
+    delphyne-crash
     delphyne-dragway
     delphyne-gazoo
     delphyne-keyop

--- a/python/examples/delphyne-crash
+++ b/python/examples/delphyne-crash
@@ -1,0 +1,9 @@
+#!/usr/bin/env python2.7
+#
+# Copyright 2018 Toyota Research Institute
+#
+
+import delphyne.demos.crash
+
+if __name__ == "__main__":
+    delphyne.demos.crash.main()

--- a/src/agents/CMakeLists.txt
+++ b/src/agents/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(helpers)
+
 ##############################################################################
 # Agents
 ##############################################################################
@@ -26,6 +28,7 @@ target_link_libraries(
     drake::drake
     Eigen3::Eigen
   PRIVATE
+    agent_helpers  
     translations
 )
 install(TARGETS agents

--- a/src/agents/helpers/CMakeLists.txt
+++ b/src/agents/helpers/CMakeLists.txt
@@ -1,0 +1,18 @@
+# ----------------------------------------
+# Agent helpers library
+
+add_library(agent_helpers frame_pose_aggregator.cc)
+
+set_target_properties(agent_helpers PROPERTIES OUTPUT_NAME ${PROJECT_NAME}-agent-helpers)
+
+target_link_libraries(
+  agent_helpers
+  PUBLIC
+    public_headers
+    ${drake_LIBRARIES}
+)
+
+install(TARGETS agent_helpers
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)

--- a/src/agents/helpers/frame_pose_aggregator.cc
+++ b/src/agents/helpers/frame_pose_aggregator.cc
@@ -1,0 +1,57 @@
+// Copyright 2018 Toyota Research Institute
+#include "agents/helpers/frame_pose_aggregator.h"
+
+#include <delphyne/macros.h>
+
+#include <drake/systems/rendering/pose_vector.h>
+
+namespace delphyne {
+
+template <typename T>
+FramePoseAggregator<T>::FramePoseAggregator(
+    const drake::geometry::SourceId& source_id)
+    : drake::systems::LeafSystem<T>(), source_id_(source_id) {
+  // Declare the output port and provide an allocator for a FramePoseVector of
+  // length equal to the concatenation of all inputs.
+  this->DeclareAbstractOutputPort(&FramePoseAggregator::MakeFramePoseVector,
+                                  &FramePoseAggregator::CalcFramePoseVector);
+}
+
+template <typename T>
+const drake::systems::InputPortDescriptor<T>&
+FramePoseAggregator<T>::DeclareInput(
+    const drake::geometry::FrameId& frame_id) {
+  // Make sure no other input was declared with the same frame ID.
+  DELPHYNE_DEMAND(std::find(frame_ids_.begin(), frame_ids_.end(),
+                            frame_id) == frame_ids_.end());
+  const drake::systems::InputPortDescriptor<T>& pose_port =
+      this->DeclareVectorInputPort(drake::systems::rendering::PoseVector<T>());
+  frame_ids_.push_back(frame_id);
+  return pose_port;
+}
+
+template <typename T>
+drake::geometry::FramePoseVector<T>
+FramePoseAggregator<T>::MakeFramePoseVector() const {
+  return drake::geometry::FramePoseVector<T>(source_id_, frame_ids_);
+}
+
+template <typename T>
+void FramePoseAggregator<T>::CalcFramePoseVector(
+    const drake::systems::Context<T>& context,
+    drake::geometry::FramePoseVector<T>* output) const {
+  using drake::systems::rendering::PoseVector;
+  output->clear();
+  const int num_ports = this->get_num_input_ports();
+  for (int port_index = 0; port_index < num_ports; ++port_index) {
+    const PoseVector<T>* input_pose =
+        this->template EvalVectorInput<PoseVector>(context, port_index);
+    output->set_value(frame_ids_[port_index], input_pose->get_isometry());
+  }
+}
+
+// TODO(hidmic): Extend support for non-double types when SceneGraph supports
+// them.
+template class FramePoseAggregator<double>;
+
+}  // namespace delphyne

--- a/src/agents/helpers/frame_pose_aggregator.h
+++ b/src/agents/helpers/frame_pose_aggregator.h
@@ -1,0 +1,53 @@
+// Copyright 2018 Toyota Research Institute
+
+#pragma once
+
+#include <vector>
+
+#include <drake/common/drake_copyable.h>
+#include <drake/geometry/frame_kinematics_vector.h>
+#include <drake/geometry/geometry_ids.h>
+#include <drake/systems/framework/context.h>
+#include <drake/systems/framework/input_port_descriptor.h>
+#include <drake/systems/framework/leaf_system.h>
+
+namespace delphyne {
+
+/// A system that aggregates drake::systems::rendering::PoseVector inputs
+/// into a single drake::geometry::FramePoseVector output, each one associated
+/// to a specific frame ID. Akin in functionality to
+/// drake::systems::rendering::PoseAggregator.
+///
+/// @tparam T A valid Eigen scalar type.
+template <typename T>
+class FramePoseAggregator : public drake::systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FramePoseAggregator)
+
+  /// Constructs an aggregator that uses the given @p source_id.
+  explicit FramePoseAggregator(const drake::geometry::SourceId& source_id);
+
+  /// Declares a pose input port, associated with the given @p frame_id.
+  /// @return The input drake::systems::rendering::PoseVector port
+  /// descriptor.
+  const drake::systems::InputPortDescriptor<T>& DeclareInput(
+      const drake::geometry::FrameId& frame_id);
+
+ private:
+  // Returns a new drake::geometry::FramePoseVector instance to
+  // populate.
+  drake::geometry::FramePoseVector<T> MakeFramePoseVector() const;
+
+  // Builds the outgoing drake::geometry::FramePoseVector based on
+  // declared drake::systems::rendering::PoseVector inputs.
+  void CalcFramePoseVector(const drake::systems::Context<T>& context,
+                           drake::geometry::FramePoseVector<T>* output) const;
+
+  // Aggregator's source ID to tag the outgoing drake::geometry::FramePoseVector
+  // instances (@see MakeFramePoseVector()).
+  const drake::geometry::SourceId source_id_{};
+  // Aggregator inputs' associated frame IDs.
+  std::vector<drake::geometry::FrameId> frame_ids_{};
+};
+
+}  // namespace delphyne

--- a/src/agents/helpers/geometry_wiring.h
+++ b/src/agents/helpers/geometry_wiring.h
@@ -1,0 +1,123 @@
+// Copyright 2018 Toyota Research Institute
+#pragma once
+
+#include <memory>
+#include <string>
+#include <set>
+#include <utility>
+
+#include <drake/common/eigen_types.h>
+#include <drake/geometry/geometry_frame.h>
+#include <drake/geometry/geometry_ids.h>
+#include <drake/geometry/geometry_instance.h>
+#include <drake/geometry/shape_specification.h>
+#include <drake/systems/primitives/constant_vector_source.h>
+
+#include "agents/helpers/frame_pose_aggregator.h"
+
+namespace delphyne {
+
+namespace detail {
+
+/// Combines drake::geometry::FrameId name from @p root (i.e. prefix)
+/// and @p leaf names.
+inline std::string ResolveFrameName(const std::string& root,
+                                    const std::string& leaf) {
+  if (root.empty()) return leaf;
+  return root + "_" + leaf;
+}
+
+}  // namespace detail
+
+/// Wires up a Prius car geometry (and associated systems) using the given
+/// @p builder and @p scene_graph.
+///
+/// @param frame_root A root name (i.e. a prefix) for all Prius car frames.
+/// @param initial_world_to_car_transform The initial world to Prius car
+///                                       transform.
+/// @param builder The builder used to wire associated systems into
+///                the diagram.
+/// @param scene_graph The scene graph where geometries are registered into.
+/// @param geometry_ids Output set of registered geometry IDs.
+/// @return The Prius car drake::systems::rendering::PoseVector (abstract) port
+///         to update its pose (i.e. the pose of the whole care frame) in the
+///         world.
+/// @tparam T A valid Eigen scalar type.
+// TODO(hidmic): Extend support for non-double types when SceneGraph supports
+// them.
+template <typename T,
+          typename std::enable_if<
+            std::is_same<T, double>::value, int>::type = 0>
+const drake::systems::InputPortDescriptor<T>& WirePriusGeometry(
+    const std::string& frame_root,
+    const drake::Isometry3<T>& initial_world_to_car_transform,
+    drake::systems::DiagramBuilder<T>* builder,
+    drake::geometry::SceneGraph<T>* scene_graph,
+    std::set<drake::geometry::GeometryId>* geometry_ids) {
+  using drake::Isometry3;
+  using drake::Quaternion;
+  using drake::Translation3;
+  using drake::geometry::Box;
+  using drake::geometry::SourceId;
+  using drake::geometry::FrameId;
+  using drake::geometry::GeometryFrame;
+  using drake::geometry::GeometryInstance;
+  using drake::systems::ConstantVectorSource;
+  using drake::systems::rendering::PoseVector;
+
+  // Prius' dimensional constants have been retrieved or computed from its SDF
+  // (currently living in Drake).
+  const T kPriusCarLength{4.6257};  // in meters.
+  const T kPriusCarWidth{1.8208};  // in meters.
+  const T kPriusCarHeight{1.3957};  // in meters.
+  const Translation3<T> kPriusCarToChassisTranslation(1.40948, 0., 0.69785);
+  const Quaternion<T> kPriusCarToChassisRotation{Quaternion<T>::Identity()};
+
+  // Registers a source for the given scene graph.
+  const SourceId source_id = scene_graph->RegisterSource(frame_root);
+  // Registers the Prius car frame.
+  const GeometryFrame car_frame(
+      detail::ResolveFrameName(frame_root, "car_frame"),
+      initial_world_to_car_transform);
+  const FrameId car_frame_id =
+      scene_graph->RegisterFrame(source_id, car_frame);
+
+  // Registers the Prius car chassis frame.
+  const GeometryFrame car_chassis_frame(
+      detail::ResolveFrameName(frame_root, "car_chassis_frame"),
+      kPriusCarToChassisTranslation * kPriusCarToChassisRotation);
+  const FrameId car_chassis_frame_id = scene_graph->RegisterFrame(
+      source_id, car_frame_id, car_chassis_frame);
+
+  // Registers a bounding box geometry for the whole car with the
+  // car chassis frame as its origin.
+  auto car_bounding_box =
+      std::make_unique<GeometryInstance>(
+          Isometry3<T>::Identity(), std::make_unique<Box>(
+              kPriusCarLength, kPriusCarWidth, kPriusCarHeight));
+
+  geometry_ids->insert(scene_graph->RegisterGeometry(
+      source_id, car_chassis_frame_id, std::move(car_bounding_box)));
+
+  // Sets up a frame pose aggregator to deal with the
+  // drake::systems::rendering::PoseVector to drake::geometry::FramePoseVector
+  // conversions.
+  auto frame_pose_aggregator =
+      builder->template AddSystem<FramePoseAggregator<T>>(source_id);
+
+  // Fixes the car-to-chassis transform.
+  auto fixed_chassis_pose =
+      builder->template AddSystem<ConstantVectorSource<T>>(
+          PoseVector<T>(kPriusCarToChassisRotation,
+                        kPriusCarToChassisTranslation));
+
+  builder->Connect(fixed_chassis_pose->get_output_port(),
+                   frame_pose_aggregator->DeclareInput(car_chassis_frame_id));
+
+  builder->Connect(frame_pose_aggregator->get_output_port(0),
+                   scene_graph->get_source_pose_port(source_id));
+
+  return frame_pose_aggregator->DeclareInput(car_frame_id);
+}
+
+}  // namespace delphyne

--- a/src/agents/mobil_car.cc
+++ b/src/agents/mobil_car.cc
@@ -11,17 +11,28 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 #include <drake/automotive/idm_controller.h>
 #include <drake/automotive/mobil_planner.h>
 #include <drake/automotive/prius_vis.h>
 #include <drake/automotive/pure_pursuit_controller.h>
+#include <drake/common/eigen_types.h>
+#include <drake/geometry/geometry_frame.h>
+#include <drake/geometry/geometry_ids.h>
+#include <drake/geometry/geometry_instance.h>
+#include <drake/geometry/shape_specification.h>
+#include <drake/systems/primitives/constant_vector_source.h>
 #include <drake/systems/primitives/multiplexer.h>
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/PluginMacros.hh>
 
+// public headers
+#include "delphyne/macros.h"
+
 // private headers
+#include "agents/helpers/geometry_wiring.h"
 #include "backend/ign_publisher_system.h"
 #include "systems/simple_car.h"
 #include "translations/drake_simple_car_state_to_ign.h"
@@ -46,8 +57,13 @@ MobilCar::MobilCar(const std::string& name, bool direction_of_travel, double x,
 int MobilCar::Configure(
     int id, const drake::maliput::api::RoadGeometry* road_geometry,
     drake::systems::DiagramBuilder<double>* builder,
+    drake::geometry::SceneGraph<double>* scene_graph,
     drake::systems::rendering::PoseAggregator<double>* aggregator,
     drake::automotive::CarVisApplicator<double>* car_vis_applicator) {
+  DELPHYNE_DEMAND(builder != nullptr);
+  DELPHYNE_DEMAND(scene_graph != nullptr);
+  DELPHYNE_DEMAND(aggregator != nullptr);
+  DELPHYNE_DEMAND(car_vis_applicator != nullptr);
   igndbg << "MobilCar configure" << std::endl;
 
   /*********************
@@ -176,6 +192,17 @@ int MobilCar::Configure(
                    ports.velocity_descriptor);
   car_vis_applicator->AddCarVis(
       std::make_unique<drake::automotive::PriusVis<double>>(id, name_));
+
+  // Computes the initial world to car transform X_WC0.
+  const drake::Isometry3<double> X_WC0 =
+      drake::Translation3<double>(initial_parameters_.x,
+                                  initial_parameters_.y, 0.)
+      * drake::AngleAxis<double>(initial_parameters_.heading,
+                                 drake::Vector3<double>::UnitZ());
+
+  // Wires up the Prius geometry.
+  builder->Connect(simple_car_system->pose_output(), WirePriusGeometry(
+      name_, X_WC0, builder, scene_graph, &geometry_ids_));
 
   return 0;
 }

--- a/src/agents/mobil_car.h
+++ b/src/agents/mobil_car.h
@@ -14,6 +14,7 @@
 
 #include <drake/automotive/car_vis_applicator.h>
 #include <drake/common/drake_copyable.h>
+#include <drake/geometry/scene_graph.h>
 #include <drake/systems/framework/diagram_builder.h>
 #include <drake/systems/framework/system.h>
 #include <drake/systems/rendering/pose_aggregator.h>
@@ -59,6 +60,7 @@ class MobilCar : public delphyne::Agent {
   int Configure(
       int id, const drake::maliput::api::RoadGeometry* road_geometry,
       drake::systems::DiagramBuilder<double>* builder,
+      drake::geometry::SceneGraph<double>* scene_graph,
       drake::systems::rendering::PoseAggregator<double>* aggregator,
       drake::automotive::CarVisApplicator<double>* car_vis_applicator) override;
 

--- a/src/agents/rail_car.h
+++ b/src/agents/rail_car.h
@@ -16,6 +16,7 @@
 #include <drake/automotive/gen/maliput_railcar_state.h>
 #include <drake/automotive/maliput/api/lane.h>
 #include <drake/automotive/maliput/api/road_geometry.h>
+#include <drake/geometry/scene_graph.h>
 #include <drake/common/drake_copyable.h>
 #include <drake/systems/framework/diagram_builder.h>
 #include <drake/systems/framework/system.h>
@@ -69,6 +70,7 @@ class RailCar : public delphyne::Agent {
   int Configure(
       int id, const drake::maliput::api::RoadGeometry* road_geometry,
       drake::systems::DiagramBuilder<double>* builder,
+      drake::geometry::SceneGraph<double>* scene_graph,
       drake::systems::rendering::PoseAggregator<double>* aggregator,
       drake::automotive::CarVisApplicator<double>* car_vis_applicator) override;
 

--- a/src/agents/simple_car.h
+++ b/src/agents/simple_car.h
@@ -14,6 +14,7 @@
 
 #include <drake/automotive/car_vis_applicator.h>
 #include <drake/automotive/gen/simple_car_state.h>
+#include <drake/geometry/scene_graph.h>
 #include <drake/systems/framework/diagram_builder.h>
 #include <drake/systems/framework/system.h>
 #include <drake/systems/rendering/pose_aggregator.h>
@@ -39,6 +40,7 @@ class SimpleCar : public delphyne::Agent {
   int Configure(
       int id, const drake::maliput::api::RoadGeometry* road_geometry,
       drake::systems::DiagramBuilder<double>* builder,
+      drake::geometry::SceneGraph<double>* scene_graph,
       drake::systems::rendering::PoseAggregator<double>* aggregator,
       drake::automotive::CarVisApplicator<double>* car_vis_applicator) override;
 

--- a/src/agents/trajectory_agent.h
+++ b/src/agents/trajectory_agent.h
@@ -15,6 +15,7 @@
 
 #include <drake/automotive/car_vis_applicator.h>
 #include <drake/automotive/trajectory.h>
+#include <drake/geometry/scene_graph.h>
 #include <drake/systems/framework/diagram_builder.h>
 #include <drake/systems/framework/system.h>
 #include <drake/systems/rendering/pose_aggregator.h>
@@ -41,10 +42,12 @@ class TrajectoryAgent : public delphyne::Agent {
   int Configure(
       int id, const drake::maliput::api::RoadGeometry* road_geometry,
       drake::systems::DiagramBuilder<double>* builder,
+      drake::geometry::SceneGraph<double>* scene_graph,
       drake::systems::rendering::PoseAggregator<double>* aggregator,
       drake::automotive::CarVisApplicator<double>* car_vis_applicator) override;
 
  private:
+  const double initial_time_{};
   std::unique_ptr<drake::automotive::Trajectory> trajectory_{};
 };
 

--- a/src/backend/automotive_simulator.h
+++ b/src/backend/automotive_simulator.h
@@ -21,6 +21,7 @@
 #include <drake/automotive/simple_car.h>
 #include <drake/automotive/trajectory_car.h>
 #include <drake/common/drake_copyable.h>
+#include <drake/geometry/scene_graph.h>
 #include <drake/multibody/rigid_body_tree.h>
 #include <drake/systems/analysis/simulator.h>
 #include <drake/systems/framework/diagram.h>
@@ -75,7 +76,7 @@ class AutomotiveSimulator {
    * ready this agent for use in the simulation.
    *
    * @param agent[in] The user provided agent to add to the simulation.
-   * @return A simulator generated unqiue id for the agent.
+   * @return A simulator generated unique id for the agent.
    */
   int AddAgent(std::unique_ptr<delphyne::AgentBase<T>> agent);
 
@@ -119,6 +120,16 @@ class AutomotiveSimulator {
   ///
   /// @pre Start() has been called.
   drake::systems::rendering::PoseBundle<T> GetCurrentPoses() const;
+
+  /// Returns all agent ID pairs that are currently in collision.
+  ///
+  /// @remarks The order in which collision pairs are returned may
+  ///          vary with the collision detection backend used and thus
+  ///          no order is enforced. DO NOT expect nor rely on any given
+  ///          order.
+  /// @pre Start() has been called.
+  /// @warning Failure to meet any of the preconditions will abort execution.
+  const std::vector<std::pair<int, int>> GetCollisions() const;
 
   /// Calls Build() on the diagram (if it has not been build already) and
   /// initializes the Simulator.  No further changes to the diagram may occur
@@ -201,6 +212,14 @@ class AutomotiveSimulator {
   // Creates a scene message from a geometry description and up-to-date poses
   // for non-static elements.
   SceneSystem* scene_system_{};
+
+  // The scene graph used to register all agents geometries within
+  // the simulation.
+  drake::geometry::SceneGraph<T>* scene_graph_{};
+
+  // The scene query associated with the scene graph of the simulation,
+  // for later geometrical queries (i.e. collisions).
+  std::unique_ptr<drake::systems::AbstractValue> scene_query_{};
 
   // Takes the output of car_vis_applicator_ and creates an lcmt_viewer_draw
   // message containing the latest poses of the visual elements.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ macro(delphyne_build_tests)
       ${BINARY_NAME}
       PRIVATE
         agents
+        agent_helpers
         simulation_runner
         automotive_simulator
         scene_system

--- a/test/regression/cpp/CMakeLists.txt
+++ b/test/regression/cpp/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SOURCES
   automotive_simulator_test.cc
   drake_driving_command_to_ign_translator_system_test.cc
   drake_simple_car_state_to_ign_translator_system_test.cc
+  frame_pose_aggregator_test.cc
   ign_driving_command_to_drake_translator_system_test.cc
   ign_model_v_to_lcm_viewer_draw_translator_system_test.cc
   ign_models_assembler_test.cc

--- a/test/regression/cpp/frame_pose_aggregator_test.cc
+++ b/test/regression/cpp/frame_pose_aggregator_test.cc
@@ -1,0 +1,68 @@
+// Copyright 2018 Toyota Research Institute
+
+#include "agents/helpers/frame_pose_aggregator.h"
+
+#include <memory>
+
+#include <drake/common/eigen_types.h>
+#include <drake/geometry/geometry_ids.h>
+#include <drake/systems/framework/context.h>
+#include <drake/systems/framework/input_port_descriptor.h>
+#include <drake/systems/framework/output_port_value.h>
+#include <drake/systems/framework/value.h>
+#include <drake/systems/rendering/pose_vector.h>
+
+#include <gtest/gtest.h>
+
+namespace delphyne {
+namespace {
+
+GTEST_TEST(FramePoseAggregatorTest, CorrectAggregation) {
+  const drake::geometry::SourceId source_id =
+      drake::geometry::SourceId::get_new_id();
+  FramePoseAggregator<double> frame_pose_aggregator(source_id);
+
+  const drake::geometry::FrameId frame0 =
+      drake::geometry::FrameId::get_new_id();
+  const drake::systems::InputPortDescriptor<double>& input_pose_port0 =
+      frame_pose_aggregator.DeclareInput(frame0);
+  const drake::geometry::FrameId frame1 =
+      drake::geometry::FrameId::get_new_id();
+  const drake::systems::InputPortDescriptor<double>& input_pose_port1 =
+      frame_pose_aggregator.DeclareInput(frame1);
+
+  std::unique_ptr<drake::systems::Context<double>> context =
+      frame_pose_aggregator.AllocateContext();
+
+  auto input_pose0 =
+      std::make_unique<drake::systems::rendering::PoseVector<double>>(
+          drake::Quaternion<double>(0.5, 0.5, 0., 0.),
+          drake::Translation3<double>(1., 10., 100.));
+  context->FixInputPort(input_pose_port0.get_index(), input_pose0->Clone());
+
+  auto input_pose1 =
+      std::make_unique<drake::systems::rendering::PoseVector<double>>(
+          drake::Quaternion<double>(0.5, 0., 0.5, 0.),
+          drake::Translation3<double>(-1., -10., -100.));
+  context->FixInputPort(input_pose_port1.get_index(), input_pose1->Clone());
+
+  std::unique_ptr<drake::systems::SystemOutput<double>> output =
+      frame_pose_aggregator.AllocateOutput(*context);
+  frame_pose_aggregator.CalcOutput(*context, output.get());
+
+  const drake::systems::AbstractValue* output_value = output->get_data(0);
+  const auto& output_frame_pose_vector =
+      output_value->GetValue<drake::geometry::FramePoseVector<double>>();
+
+  EXPECT_EQ(output_frame_pose_vector.source_id(), source_id);
+  EXPECT_EQ(output_frame_pose_vector.size(), 2);
+  EXPECT_TRUE(output_frame_pose_vector.has_id(frame0));
+  EXPECT_TRUE(output_frame_pose_vector.value(frame0).isApprox(
+      input_pose0->get_isometry()));
+  EXPECT_TRUE(output_frame_pose_vector.has_id(frame1));
+  EXPECT_TRUE(output_frame_pose_vector.value(frame1).isApprox(
+      input_pose1->get_isometry()));
+}
+
+}  // namespace
+}  // namespace delphyne


### PR DESCRIPTION
Connected to #372. This pull request adds basic collision detection support to Delphyne, by:
- Making all agents register a bounding box geometry that encloses the Prius mesh (box size and pose are currently hardcoded).
- Implementing and exposing through python bindings a `GetCollisions()` method in the `delphyne::AutomotiveSimulator` class that returns a list of tuples with the agent ID pairs that are in collision (that eventually might return the agents themselves instead when we do so in `AddAgent()`).

It also adds yet another translating system, to aggregate `drake::systems::rendering::PoseVector` instances into a `drake::geometry::FramePoseVector` instance, suitable for `drake::geometry::SceneGraph` updates.

Finally, a simple demo is included, `delphyne-crash`, where two simple cars are set in collision course. It takes roughly ~5 sec for them to collide at the origin of the (visualized) world.

~Still WIP. I need to figure out how to augment `AutomotiveSimulator`'s test coverage properly~. Will rebase and adjust once #443 is merged. Early feedback is very much welcomed though. 