### PR TITLE
[rail_car] handle abstract state the way it was intended

### DIFF
--- a/src/systems/maliput_rail_car.h
+++ b/src/systems/maliput_rail_car.h
@@ -122,11 +122,6 @@ class MaliputRailCar final : public systems::LeafSystem<T> {
       systems::ContinuousState<T>* derivatives) const override;
 
   // LeafSystem<T> overrides.
-  void SetDefaultState(const systems::Context<T>& context,
-                       systems::State<T>* state) const override;
-
-  std::unique_ptr<systems::AbstractValues> AllocateAbstractState()
-      const override;
   optional<bool> DoHasDirectFeedthrough(int, int) const override;
   void DoCalcNextUpdateTime(const systems::Context<T>& context,
                             systems::CompositeEventCollection<T>*,


### PR DESCRIPTION
Simplifies rail car after the bugfix in systems that went in with https://github.com/RobotLocomotion/drake/pull/8934.

This PR needs to go in tandem with https://github.com/ToyotaResearchInstitute/delphyne-gui/pull/129