### PR TITLE
Adds delphyne-perf demo, to keep track of MOBIL cars performance.

### DIFF
--- a/python/delphyne/demos/CMakeLists.txt
+++ b/python/delphyne/demos/CMakeLists.txt
@@ -10,7 +10,7 @@ install(
     helpers.py
     gazoo.py
     keyop.py
-    perf.py
+    mobil_perf.py
     realtime.py
     roads.py
     scriptlets.py

--- a/python/delphyne/demos/mobil_perf.py
+++ b/python/delphyne/demos/mobil_perf.py
@@ -135,8 +135,8 @@ def dragway(args):
 def parse_arguments():
     "Argument passing and demo documentation."
     parser = helpers.create_argument_parser(
-        "Performance Check",
-        "\nCPU hungry agents on common roads.\n",
+        "MOBIL Performance Check",
+        "\nCPU hungry MOBIL cars on common roads.\n",
         default_duration=5.0)
     available_benchmarks = benchmark.register.keys()
     parser.add_argument(

--- a/python/examples/CMakeLists.txt
+++ b/python/examples/CMakeLists.txt
@@ -11,7 +11,7 @@ install(
     delphyne-dragway
     delphyne-gazoo
     delphyne-keyop
-    delphyne-perf
+    delphyne-mobil-perf
     delphyne-realtime
     delphyne-roads
     delphyne-scriptlets

--- a/python/examples/delphyne-mobil-perf
+++ b/python/examples/delphyne-mobil-perf
@@ -3,7 +3,7 @@
 # Copyright 2018 Toyota Research Institute
 #
 
-import delphyne.demos.perf
+import delphyne.demos.mobil_perf
 
 if __name__ == "__main__":
-    delphyne.demos.perf.main()
+    delphyne.demos.mobil_perf.main()


### PR DESCRIPTION
This pull requests adds a simple demo, with no visualizer, that run a configurable amount of MOBIL cars (20 by default) on typical roads: a 4-lane dragway, a 3-lane straight Multilane road and 3-lane curved (arc) Multilane road.

To be merged along with https://github.com/ToyotaResearchInstitute/delphyne-gui/pull/140.