### PR TITLE
Removed duplicated dependency from CI

### DIFF
--- a/tools/continuous_integration/jenkins/setup_early
+++ b/tools/continuous_integration/jenkins/setup_early
@@ -19,7 +19,6 @@ awscli
 curl
 git
 libignition-cmake-dev
-libsqlite3-dev
 mercurial
 pkg-config
 pylint


### PR DESCRIPTION
Follow-up of [delphyne-gui#143](https://github.com/ToyotaResearchInstitute/delphyne-gui/pull/143).
Removes a dependency from CI's setup script, since now it's installed from within the `install_prereqs.sh`.