### PR TITLE
Advertise step service in replayer

### DIFF
--- a/src/backend/replayer.cc
+++ b/src/backend/replayer.cc
@@ -48,15 +48,6 @@ class Replayer {
   // Advertises the play/resume services and controls the flow of the
   // logfile's playback.
   int Run() {
-    // Setup all services.
-    if (!SetupSceneServices()) {
-      ignerr << "Cannot provide scene services." << std::endl;
-      return 1;
-    }
-    if (!SetupPlaybackServices()) {
-      ignerr << "Cannot provide playback services." << std::endl;
-      return 1;
-    }
     // Register all topics to be played-back.
     const int64_t topics_add_result = player_.AddTopic(std::regex(".*"));
     if (topics_add_result == 0) {
@@ -72,6 +63,15 @@ class Replayer {
     handle_ = player_.Start();
     if (!handle_) {
       ignerr << "Failed to start playback" << std::endl;
+      return 1;
+    }
+    // Setup all services.
+    if (!SetupSceneServices()) {
+      ignerr << "Cannot provide scene services." << std::endl;
+      return 1;
+    }
+    if (!SetupPlaybackServices()) {
+      ignerr << "Cannot provide playback services." << std::endl;
       return 1;
     }
 


### PR DESCRIPTION
Depends on [ign-transport#339](https://bitbucket.org/ignitionrobotics/ign-transport/pull-requests/339), so merging is blocked until:
- The ignition-transport PR goes in
- A second PR updates the `ign-transport` commit in the `delphyne.repos` file in `delphyne-gui`.

Fixes second item from the "Stepping log playback" list in #493 .

- Advertises a `/replayer/step` service that expects an `ignition::msgs::Time` message and steps the playback by the given time.