### PR TITLE
Synchronizes simulation logs with simulation time

### DIFF
--- a/src/backend/data_logger.cc
+++ b/src/backend/data_logger.cc
@@ -111,6 +111,17 @@ DataLogger::~DataLogger() {
   }
 }
 
+void DataLogger::Sync(const ignition::transport::Clock* clock) {
+  DELPHYNE_VALIDATE(clock != nullptr, std::runtime_error,
+                    "Given clock is null.");
+  DELPHYNE_VALIDATE(!is_logging(), std::runtime_error,
+                    "Cannot synchronize logs if already running.");
+  using ignition::transport::log::RecorderError;
+  const RecorderError result = topic_recorder_.Sync(clock);
+  DELPHYNE_VALIDATE(result == RecorderError::SUCCESS, std::runtime_error,
+                    "Failed to synchronize topic recordings.");
+}
+
 void DataLogger::Start(const std::string& filename) {
   DELPHYNE_VALIDATE(!is_logging(), std::runtime_error,
                     "Cannot start logging, already running.");

--- a/src/backend/data_logger.h
+++ b/src/backend/data_logger.h
@@ -30,6 +30,14 @@ class DataLogger {
 
   ~DataLogger();
 
+  /// Synchronizes data logging with the given @p clock.
+  /// @throws std::runtime_error if clock is nullptr.
+  /// @throws std::runtime_error if the logger is running already
+  ///                            (i.e. is_logging() is true).
+  /// @throws std::runtime_error if it fails to synchronize with the
+  ///                            given @p clock.
+  void Sync(const ignition::transport::Clock* clock);
+
   /// Starts data logging, to be bundled into @p filename (plus the '.dz'
   /// extension).
   ///
@@ -86,7 +94,8 @@ class DataLogger {
   std::string tmppath_{""};
   // @brief Path to logging archive.
   std::string logpath_{""};
-  // @brief A recorder of ignition transport topics.
+  // @brief A recorder of ignition transport topics, synchronized
+  // with the simulation time.
   ignition::transport::log::Recorder topic_recorder_;
   // @brief A bundled package to log meshes into.
   std::unique_ptr<utility::BundledPackage> package_{nullptr};

--- a/src/backend/simulation_runner.h
+++ b/src/backend/simulation_runner.h
@@ -326,6 +326,9 @@ class SimulatorRunner {
   // @brief The topic used to publish world stats.
   static constexpr char const* kWorldStatsTopic = "/world_stats";
 
+  // @brief The topic used to publish clock to.
+  static constexpr char const* kClockTopic = "/clock";
+
   // @brief The service used when receiving a scene request.
   static constexpr char const* kSceneRequestServiceName = "/get_scene";
 
@@ -446,6 +449,9 @@ class SimulatorRunner {
 
   // @brief An Ignition Transport publisher for sending world stats.
   ignition::transport::Node::Publisher world_stats_pub_;
+
+  // @brief An Ignition Transport Clock to distribute the simulated clock.
+  ignition::transport::NetworkClock clock_;
 
   // @brief A vector that holds all the registered callbacks that need to be
   // triggered on each simulation step.


### PR DESCRIPTION
Precisely what the title says. Along with [ignition-transport#340](https://bitbucket.org/ignitionrobotics/ign-transport/pull-requests/340/adds-alternative-clock-support-to-the-log), this pull request adds the necessary machinery to have Delphyne simulation logs stamped with _simulation time_ (that of the `Simulator`) as opposed to _real time_ (that of the host OS).

Connected to #520. To be merged with an upcoming `delphyne-gui` PR that brings (soon to be) latest `ignition-transport` additions.