### PR TITLE
Fixed flaky test in filesystem_test

### DIFF
--- a/test/regression/cpp/filesystem_test.cc
+++ b/test/regression/cpp/filesystem_test.cc
@@ -68,7 +68,7 @@ TEST(FileSystemTest, WalkDirectory) {
   };
 
   // Make sure the walked_paths are alpha-sorted.
-  sort(walked_paths.begin(), walked_paths.end());
+  std::sort(walked_paths.begin(), walked_paths.end());
 
   EXPECT_THROW(WalkDirectory("not-a-directory", walkfn, kRecursive),
                std::runtime_error);


### PR DESCRIPTION
Even while the items within the `walked_paths` vector are always consistent in content, they're not in order, so it may occur that whether the `var` or  `etc` path appear one before the other.
Since we're iterating over the content of this vector from beginning to end, we needed the order of its elements be consistent.
So to fix this issue we:
- Define both the `first_expected_paths` and `all_expected_paths` in an alpha-sorted way.
- Alpha-sort the `walked_paths` vector after it has been generated (so that the order of the paths is always the same)
 