### PR TITLE
Fixed flaky test in filesystem_test 2.0

### DIFF
--- a/test/regression/cpp/filesystem_test.cc
+++ b/test/regression/cpp/filesystem_test.cc
@@ -71,14 +71,12 @@ TEST(FileSystemTest, WalkDirectory) {
                std::runtime_error);
 
   WalkDirectory(testdir, walkfn, kRecursive);
-
-  EXPECT_TRUE(all_expected_paths == walked_paths);
+  EXPECT_EQ(all_expected_paths, walked_paths);
 
   walked_paths.clear();
 
   WalkDirectory(testdir, walkfn, kNotRecursive);
-
-  EXPECT_TRUE(first_expected_paths == walked_paths);
+  EXPECT_EQ(first_expected_paths, walked_paths);
 
   ignition::common::removeAll(testdir);
 }


### PR DESCRIPTION
Fixes the filesystem_test (previously attempted to be fixed in #530) that's making our CI to fail.
Replaces the vectors with sets, making the comparison across them to be position-independent.