### PR TITLE
Add support for MTL material file inspection

### DIFF
--- a/include/delphyne/utility/resources/meshes.h
+++ b/include/delphyne/utility/resources/meshes.h
@@ -30,8 +30,6 @@ namespace utility {
 *****************************************************************************/
 
 /// A Resource representation of an OBJ mesh file.
-// TODO(hidmic): Consider using a parser instead of
-//               plain regular expressions.
 class OBJFile : public GenericResource {
  public:
   DELPHYNE_NO_COPY_NO_MOVE_NO_ASSIGN(OBJFile);
@@ -54,6 +52,19 @@ class ColladaFile : public GenericResource {
   /// @param uri Identifier of the Collada mesh.
   explicit ColladaFile(const ignition::common::URI& uri);
 };
+
+/// A Resource representation of an MTL material file as
+/// found in OBJ files.
+class MTLFile : public GenericResource {
+ public:
+  DELPHYNE_NO_COPY_NO_MOVE_NO_ASSIGN(MTLFile);
+
+  /// Constructs representation for the MTL material
+  /// file associated with the given @p uri.
+  /// @param uri Identifier of the MTL material.
+  explicit MTLFile(const ignition::common::URI& uri);
+};
+
 
 /*****************************************************************************
 ** Trailers

--- a/src/utility/resources/inspection.cc
+++ b/src/utility/resources/inspection.cc
@@ -27,6 +27,7 @@ ResourceInspector* ResourceInspector::Instance() {
 ResourceInspector::ResourceInspector() {
   AssociateExtension("obj", ResourceSubtype<OBJFile>::Instance());
   AssociateExtension("dae", ResourceSubtype<ColladaFile>::Instance());
+  AssociateExtension("mtl", ResourceSubtype<MTLFile>::Instance());
 }
 
 void ResourceInspector::AssociateExtension(const std::string& extension,

--- a/src/utility/resources/meshes.cc
+++ b/src/utility/resources/meshes.cc
@@ -33,5 +33,9 @@ ColladaFile::ColladaFile(const ignition::common::URI& uri)
     : GenericResource(uri, MakePathRegex("\\.(jpg|png)")) {
 }
 
+MTLFile::MTLFile(const ignition::common::URI& uri)
+    : GenericResource(uri, MakePathRegex("\\.(jpg|png)")) {
+}
+
 }  // namespace utility
 }  // namespace delphyne

--- a/test/regression/cpp/resources_test.cc
+++ b/test/regression/cpp/resources_test.cc
@@ -91,6 +91,44 @@ TEST_F(ResourceInspectionTest, OBJMeshInspection) {
   EXPECT_EQ(path_to_mtllib, path_to_dep);
 }
 
+TEST_F(ResourceInspectionTest, MTLMaterialInspection) {
+  const std::string path_to_material_file =
+      ignition::common::joinPaths(tmpdir(), "demo.mtl");
+  std::ofstream material_fs(path_to_material_file);
+  material_fs << "newmtl demo"
+              << "Ka 0.588 0.588 0.588"
+              << "Kd 1 1 1"
+              << "Ks 0.9 0.9 0.9"
+              << "illum 2"
+              << "Ns 14.9285"
+              << "map_Kd green_grass.jpg"
+              << "map_bump"
+              << "bump"
+              << "map_opacity"
+              << "map_d"
+              << "refl"
+              << "map_kS"
+              << "map_kA"
+              << "map_Ns";
+  material_fs.flush();
+  material_fs.close();
+
+  const ignition::common::URI material_uri(
+      "file://" + path_to_material_file);
+  const ResourceInspector* resource_inspector =
+      ResourceInspector::Instance();
+  ASSERT_TRUE(resource_inspector != nullptr);
+  const std::vector<ignition::common::URI> dep_uris =
+      resource_inspector->GetDependencies(material_uri);
+  ASSERT_EQ(dep_uris.size(), 1);
+  EXPECT_EQ(dep_uris[0].Scheme(), "file");
+  const std::string path_to_dep =
+      "/" + dep_uris[0].Path().Str();
+  const std::string path_to_map =
+      ignition::common::joinPaths(tmpdir(), "green_grass.jpg");
+  EXPECT_EQ(path_to_map, path_to_dep);
+}
+
 }  // namespace
 }  // namespace utility
 }  // namespace delphyne


### PR DESCRIPTION
Makes use of the extensible `ResourceInspector` architecture (added in #534) to add support for traversing `.mtl` material files in the look for file dependencies, adding them to the logfile bundle. 