### PR TITLE
Expose road network ObjFeatures

### DIFF
--- a/python/delphyne/demos/gazoo.py
+++ b/python/delphyne/demos/gazoo.py
@@ -67,11 +67,18 @@ def main():
               .format(os.path.abspath(filename)))
         quit()
 
+    features = maliput.ObjFeatures()
+    features.draw_arrows = True
+    features.draw_elevation_bounds = False
+    features.draw_stripes = True
+    features.draw_lane_haze = False
+    features.draw_branch_points = False
+
     # The road geometry
     road_geometry = simulator.set_road_geometry(
         maliput.create_multilane_from_file(
             file_path=filename
-        )
+        ), features
     )
 
     # Setup railcar 1

--- a/python/delphyne/maliput.cc
+++ b/python/delphyne/maliput.cc
@@ -15,6 +15,7 @@
 
 #include <drake/automotive/maliput/api/lane.h>
 #include <drake/automotive/maliput/api/road_geometry.h>
+#include <drake/automotive/maliput/utility/generate_obj.h>
 
 // public headers
 #include "delphyne/maliput/find_lane.h"
@@ -25,6 +26,8 @@
 *****************************************************************************/
 
 namespace py = pybind11;
+
+using drake::maliput::utility::ObjFeatures;
 
 namespace {
 
@@ -59,6 +62,24 @@ PYBIND11_MODULE(maliput, m) {
 
   m.def("create_on_ramp", &delphyne::maliput::CreateOnRamp,
         "Create the exemplar highway on-ramp");
+
+  py::class_<ObjFeatures>(m, "ObjFeatures")
+      .def(py::init<>())
+      .def_readwrite("max_grid_unit", &ObjFeatures::max_grid_unit)
+      .def_readwrite("min_grid_resolution", &ObjFeatures::min_grid_resolution)
+      .def_readwrite("draw_elevation_bounds",
+                     &ObjFeatures::draw_elevation_bounds)
+      .def_readwrite("draw_stripes", &ObjFeatures::draw_stripes)
+      .def_readwrite("draw_arrows", &ObjFeatures::draw_arrows)
+      .def_readwrite("draw_lane_haze", &ObjFeatures::draw_lane_haze)
+      .def_readwrite("draw_branch_points", &ObjFeatures::draw_branch_points)
+      .def_readwrite("stripe_width", &ObjFeatures::stripe_width)
+      .def_readwrite("stripe_elevation", &ObjFeatures::stripe_elevation)
+      .def_readwrite("arrow_elevation", &ObjFeatures::arrow_elevation)
+      .def_readwrite("lane_haze_elevation", &ObjFeatures::lane_haze_elevation)
+      .def_readwrite("branch_point_elevation",
+                     &ObjFeatures::branch_point_elevation)
+      .def_readwrite("branch_point_height", &ObjFeatures::branch_point_height);
 }
 
 /*****************************************************************************

--- a/python/delphyne/simulation.cc
+++ b/python/delphyne/simulation.cc
@@ -100,25 +100,19 @@ PYBIND11_MODULE(simulation, m) {
       .def("unpause_simulation", &SimulatorRunner::UnpauseSimulation)
       .def("request_simulation_step_execution",
            &SimulatorRunner::RequestSimulationStepExecution)
-      .def("get_simulator",
-           &SimulatorRunner::GetSimulator,
+      .def("get_simulator", &SimulatorRunner::GetSimulator,
            py::return_value_policy::reference_internal)
-      .def("get_mutable_simulator",
-           &SimulatorRunner::GetMutableSimulator,
+      .def("get_mutable_simulator", &SimulatorRunner::GetMutableSimulator,
            py::return_value_policy::reference_internal)
       .def("get_stats", &SimulatorRunner::get_stats,
            py::return_value_policy::reference)
-      .def("is_logging",
-           &SimulatorRunner::IsLogging)
+      .def("is_logging", &SimulatorRunner::IsLogging)
       .def("start_logging",
-           (void (SimulatorRunner::*)(void))&SimulatorRunner::StartLogging)
-      .def("start_logging",
-          (void (SimulatorRunner::*)(const std::string&))
-          &SimulatorRunner::StartLogging)
-      .def("stop_logging",
-           &SimulatorRunner::StopLogging)
-      .def("get_log_filename",
-           &SimulatorRunner::GetLogFilename);
+           (void (SimulatorRunner::*)(void)) & SimulatorRunner::StartLogging)
+      .def("start_logging", (void (SimulatorRunner::*)(const std::string&)) &
+                                SimulatorRunner::StartLogging)
+      .def("stop_logging", &SimulatorRunner::StopLogging)
+      .def("get_log_filename", &SimulatorRunner::GetLogFilename);
 
   py::class_<AutomotiveSimulator<double>>(m, "AutomotiveSimulator")
       .def(py::init(
@@ -128,9 +122,19 @@ PYBIND11_MODULE(simulation, m) {
       .def("get_collisions", &AutomotiveSimulator<double>::GetCollisions,
            py::return_value_policy::reference_internal)
       .def("start", &AutomotiveSimulator<double>::Start)
-      .def("set_road_geometry", &AutomotiveSimulator<double>::SetRoadGeometry,
+      .def("set_road_geometry",
+           py::overload_cast<
+               std::unique_ptr<const drake::maliput::api::RoadGeometry>>(
+               &AutomotiveSimulator<double>::SetRoadGeometry),
            "Transfer a road geometry to the control of the simulator",
            py::arg("road_geometry"))
+      .def("set_road_geometry",
+           py::overload_cast<
+               std::unique_ptr<const drake::maliput::api::RoadGeometry>,
+               const drake::maliput::utility::ObjFeatures&>(
+               &AutomotiveSimulator<double>::SetRoadGeometry),
+           "Transfer a road geometry to the control of the simulator",
+           py::arg("road_geometry"), py::arg("features"))
       .def("get_current_simulation_time",
            &AutomotiveSimulator<double>::GetCurrentSimulationTime)
       .def("get_mutable_context",

--- a/src/backend/automotive_simulator.h
+++ b/src/backend/automotive_simulator.h
@@ -15,6 +15,7 @@
 #include <drake/automotive/idm_controller.h>
 #include <drake/automotive/lane_direction.h>
 #include <drake/automotive/maliput/api/road_geometry.h>
+#include <drake/automotive/maliput/utility/generate_obj.h>
 #include <drake/automotive/maliput_railcar.h>
 #include <drake/automotive/mobil_planner.h>
 #include <drake/automotive/pure_pursuit_controller.h>
@@ -84,8 +85,21 @@ class AutomotiveSimulator {
   /// Sets the RoadGeometry for this simulation.
   ///
   /// @pre Start() has NOT been called.
+  ///
+  /// @param road_geometry The road geometry to use for the simulation.
   const drake::maliput::api::RoadGeometry* SetRoadGeometry(
       std::unique_ptr<const drake::maliput::api::RoadGeometry> road_geometry);
+
+  /// Sets the RoadGeometry for this simulation.
+  ///
+  /// @pre Start() has NOT been called.
+  ///
+  /// @param road_geometry The road geometry to use for the simulation.
+  /// @param features The road features that will be shown in the simulation.
+  /// @see documentation of drake::maliput::utility::ObjFeatures
+  const drake::maliput::api::RoadGeometry* SetRoadGeometry(
+      std::unique_ptr<const drake::maliput::api::RoadGeometry> road_geometry,
+      const drake::maliput::utility::ObjFeatures& features);
 
   /// Builds the Diagram.  No further changes to the diagram may occur after
   /// this has been called.
@@ -154,7 +168,10 @@ class AutomotiveSimulator {
   // Generates the URDF model of the road network and loads it into the
   // `RigidBodyTree`. Member variable `road_` must be set prior to calling this
   // method.
-  void GenerateAndLoadRoadNetworkUrdf();
+  // @param features The road features that will be shown in the simulation.
+  // @see documentation of drake::maliput::utility::ObjFeatures
+  void GenerateAndLoadRoadNetworkUrdf(
+      const drake::maliput::utility::ObjFeatures& features);
 
   // Fixes the scene geometry aggregator input port. This is performed on the
   // context, not the system itself, so this function requires the simulator to


### PR DESCRIPTION
Expose `drake::maliput::utility::ObjFeatures` so we can have more control on how road networks are displayed. Also, make the default to just show asphalt and stripes. Used `gazoo` as an example that also shows direction triangles.