### PR TITLE
Adds basic AgentBase API, leveraging underlying drake Systems and Contexts

### DIFF
--- a/include/delphyne/mi6/diagram_bundle.h
+++ b/include/delphyne/mi6/diagram_bundle.h
@@ -9,11 +9,17 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <type_traits>
+#include <utility>
 
+#include <drake/common/drake_copyable.h>
 #include <drake/systems/framework/diagram.h>
+#include <drake/systems/framework/diagram_builder.h>
 #include <drake/systems/framework/framework_common.h>  // OutputPortIndex
 #include <drake/systems/framework/input_port.h>
+#include <drake/systems/framework/output_port.h>
 
+#include "delphyne/macros.h"
 #include "delphyne/types.h"
 
 /*****************************************************************************
@@ -25,6 +31,8 @@ namespace delphyne {
 /*****************************************************************************
 ** Interfaces
 *****************************************************************************/
+
+namespace detail {
 
 /// @brief A generic bundle containing and describing a diagram.
 ///
@@ -39,15 +47,69 @@ namespace delphyne {
 /// disabled.
 ///
 /// @tparam One of double, delphyne::AutoDiff or delphyne::Symbolic.
-template <typename T>
-struct DiagramBundle {
-  DiagramBundle() = default;
-  DiagramBundle(const DiagramBundle<T>& other) = delete;
-  DiagramBundle<T>& operator=(const DiagramBundle<T>&) = delete;
+template <typename Base, typename T>
+class NamedPortSystem : public Base {
+ public:
+  static_assert(std::is_base_of<drake::systems::System<T>, Base>::value,
+                "Only a System can have their ports mapped.");
 
-  std::unique_ptr<drake::systems::Diagram<T>> diagram{};
-  std::map<std::string, drake::systems::OutputPortIndex> outputs;
-  std::map<std::string, drake::systems::InputPortIndex> inputs;
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(NamedPortSystem);
+
+  template <typename... Args>
+  explicit NamedPortSystem(Args... args) :
+      Base(std::forward<Args>(args)...) { }
+
+  void set_input_names(
+      std::map<std::string, drake::systems::InputPortIndex> inputs_mapping) {
+    inputs_mapping_ = inputs_mapping;
+  }
+
+  void set_output_names(
+      std::map<std::string, drake::systems::OutputPortIndex> outputs_mapping) {
+    outputs_mapping_ = outputs_mapping;
+  }
+
+  const drake::systems::InputPort<T>&
+  get_input_port(int port_index) const {
+    // Caveat: `System::get_input_port` is not virtual.
+    return Base::get_input_port(port_index);
+  }
+
+  const drake::systems::InputPort<T>&
+  get_input_port(const std::string& port_name) const {
+    DELPHYNE_VALIDATE(inputs_mapping_.count(port_name) != 0, std::runtime_error,
+                      "Input port \"" + port_name + "\" could not be found.");
+    return get_input_port(inputs_mapping_.at(port_name));
+  }
+
+  const drake::systems::OutputPort<T>&
+  get_output_port(int port_index) const {
+    // Caveat: `System::get_output_port` is not virtual.
+    return Base::get_output_port(port_index);
+  }
+
+  const drake::systems::OutputPort<T>&
+  get_output_port(const std::string& port_name) const {
+    DELPHYNE_VALIDATE(
+        outputs_mapping_.count(port_name) != 0, std::runtime_error,
+        "Output port \"" + port_name + "\" could not be found.");
+    return this->get_output_port(outputs_mapping_.at(port_name));
+  }
+
+ private:
+  std::map<std::string, drake::systems::InputPortIndex> inputs_mapping_{};
+  std::map<std::string, drake::systems::OutputPortIndex> outputs_mapping_{};
+};
+
+}  // namespace detail
+
+template <typename T>
+class DiagramBundle :
+      public detail::NamedPortSystem<drake::systems::Diagram<T>, T> {
+ public:
+  explicit DiagramBundle(drake::systems::DiagramBuilder<T>* builder) {
+    builder->BuildInto(this);
+  }
 };
 
 /*****************************************************************************

--- a/python/delphyne/CMakeLists.txt
+++ b/python/delphyne/CMakeLists.txt
@@ -66,6 +66,12 @@ install(
 pybind11_add_module(simulation_bindings simulation.cc)
 set_target_properties(simulation_bindings PROPERTIES OUTPUT_NAME simulation)
 
+target_include_directories(
+  simulation_bindings
+  PRIVATE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/python>
+)
+
 target_link_libraries(simulation_bindings
   PRIVATE
     backend

--- a/python/delphyne/agents.cc
+++ b/python/delphyne/agents.cc
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include <pybind11/eigen.h>
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -37,7 +38,9 @@ PYBIND11_MODULE(agents, m) {
   py::module::import("pydrake.maliput.api");
 
   py::class_<delphyne::Agent>(m, "AgentBase")
-      .def("name", &delphyne::Agent::name);
+      .def("name", &delphyne::Agent::name)
+      .def("get_pose", &delphyne::Agent::GetPose)
+      .def("get_velocity", &delphyne::Agent::GetVelocity);
 
   py::class_<delphyne::MobilCar, delphyne::Agent>(m, "MobilCar")
       .def(py::init<const std::string&, bool, double, double, double, double,

--- a/python/delphyne/simulation.cc
+++ b/python/delphyne/simulation.cc
@@ -121,6 +121,12 @@ PYBIND11_MODULE(simulation, m) {
            py::return_value_policy::reference_internal)
       .def("get_collisions", &AutomotiveSimulator<double>::GetCollisions,
            py::return_value_policy::reference_internal)
+      .def("get_agent_by_name",
+           &AutomotiveSimulator<double>::GetAgentByName,
+           py::return_value_policy::reference_internal)
+      .def("get_mutable_agent_by_name",
+           &AutomotiveSimulator<double>::GetMutableAgentByName,
+           py::return_value_policy::reference_internal)
       .def("start", &AutomotiveSimulator<double>::Start)
       .def("set_road_geometry",
            py::overload_cast<

--- a/src/agents/mobil_car.cc
+++ b/src/agents/mobil_car.cc
@@ -52,8 +52,8 @@ MobilCar::MobilCar(const std::string& name, bool direction_of_travel, double x,
                                drake::Vector3<double>::UnitZ());
 }
 
-std::unique_ptr<Agent::DiagramBundle> MobilCar::BuildDiagram() const {
-  DiagramBuilder builder(name_);
+std::unique_ptr<Agent::Diagram> MobilCar::BuildDiagram() const {
+  DiagramBuilder builder(this->name());
 
   /******************************************
    * Initial Context Variables
@@ -75,30 +75,30 @@ std::unique_ptr<Agent::DiagramBundle> MobilCar::BuildDiagram() const {
           road_geometry_, initial_parameters_.direction_of_travel,
           RoadPositionStrategy::kExhaustiveSearch,
           0. /* time period (unused) */));
-  mobil_planner->set_name(name_ + "_mobil_planner");
+  mobil_planner->set_name(this->name() + "_mobil_planner");
 
   IDMController<double>* idm_controller =
       builder.AddSystem(std::make_unique<IDMController<double>>(
           road_geometry_, ScanStrategy::kBranches,
           RoadPositionStrategy::kExhaustiveSearch,
           0. /* time period (unused) */));
-  idm_controller->set_name(name_ + "_idm_controller");
+  idm_controller->set_name(this->name() + "_idm_controller");
 
   delphyne::PurePursuitController<double>* pursuit = builder.AddSystem(
       std::make_unique<delphyne::PurePursuitController<double>>());
-  pursuit->set_name(name_ + "_pure_pursuit_controller");
+  pursuit->set_name(this->name() + "_pure_pursuit_controller");
 
   typedef SimpleCar2<double> SimpleCarSystem;
   SimpleCarSystem* simple_car_system =
       builder.AddSystem(std::make_unique<SimpleCarSystem>(
           context_continuous_state, context_numeric_parameters));
-  simple_car_system->set_name(name_ + "_simple_car");
+  simple_car_system->set_name(this->name() + "_simple_car");
 
   drake::systems::Multiplexer<double>* mux =
       builder.AddSystem<drake::systems::Multiplexer<double>>(
           std::make_unique<drake::systems::Multiplexer<double>>(
               DrivingCommand<double>()));
-  mux->set_name(name_ + "_mux");
+  mux->set_name(this->name() + "_mux");
 
   /*********************
    * Diagram Wiring
@@ -135,7 +135,7 @@ std::unique_ptr<Agent::DiagramBundle> MobilCar::BuildDiagram() const {
   builder.ExportPoseOutput(simple_car_system->pose_output());
   builder.ExportVelocityOutput(simple_car_system->velocity_output());
 
-  return std::move(builder.Build());
+  return builder.Build();
 }
 
 }  // namespace delphyne

--- a/src/agents/mobil_car.h
+++ b/src/agents/mobil_car.h
@@ -54,8 +54,6 @@ class MobilCar : public delphyne::Agent {
            double y, double heading, double speed,
            const drake::maliput::api::RoadGeometry& road_geometry);
 
-  std::unique_ptr<DiagramBundle> BuildDiagram() const;
-
  private:
   struct Parameters {
     bool direction_of_travel{true};
@@ -72,6 +70,8 @@ class MobilCar : public delphyne::Agent {
           heading(heading),
           speed(speed) {}
   } initial_parameters_;
+
+  std::unique_ptr<Diagram> BuildDiagram() const override;
 
   const drake::maliput::api::RoadGeometry& road_geometry_;
 };

--- a/src/agents/rail_car.cc
+++ b/src/agents/rail_car.cc
@@ -97,8 +97,8 @@ RailCar::RailCar(const std::string& name, const drake::maliput::api::Lane& lane,
       "RoadGeometry.");
 }
 
-std::unique_ptr<Agent::DiagramBundle> RailCar::BuildDiagram() const {
-  DiagramBuilder builder(name_);
+std::unique_ptr<Agent::Diagram> RailCar::BuildDiagram() const {
+  DiagramBuilder builder(name());
 
   /******************************************
    * Initial Context Variables
@@ -129,7 +129,7 @@ std::unique_ptr<Agent::DiagramBundle> RailCar::BuildDiagram() const {
       builder.AddSystem(std::make_unique<RailFollower<double>>(
           lane_direction, context_continuous_state,
           context_numeric_parameters));
-  rail_follower_system->set_name(name_ + "_system");
+  rail_follower_system->set_name(name() + "_system");
 
   vel_setter_ = builder.template AddSystem(
       std::make_unique<delphyne::VectorSource<double>>(-1));
@@ -152,10 +152,12 @@ std::unique_ptr<Agent::DiagramBundle> RailCar::BuildDiagram() const {
   builder.ExportPoseOutput(rail_follower_system->pose_output());
   builder.ExportVelocityOutput(rail_follower_system->velocity_output());
 
-  return std::move(builder.Build());
+  return builder.Build();
 }
 
 void RailCar::SetSpeed(double new_speed_mps) {
+  DELPHYNE_VALIDATE(vel_setter_ != nullptr, std::runtime_error,
+                    "This rail car is not a part of a simulation!");
   vel_setter_->Set(new_speed_mps);
 }
 

--- a/src/agents/rail_car.h
+++ b/src/agents/rail_car.h
@@ -42,11 +42,10 @@ namespace delphyne {
 /// (how far along the track) and the agent will follow
 /// this track exactly - the only variance it is permitted is the speed
 /// with which it follows the track.
-class RailCar : public delphyne::Agent {
+class RailCar : public Agent {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RailCar)
 
-  ///
   /// @brief Default constructor
   ///
   /// @param name[in] Unique name for the agent.
@@ -66,9 +65,6 @@ class RailCar : public delphyne::Agent {
           double speed, double nominal_speed,
           const drake::maliput::api::RoadGeometry& road_geometry);
 
-  std::unique_ptr<DiagramBundle> BuildDiagram() const;
-
-  ///
   /// @brief Change the speed of this agent.
   ///
   /// @param new_speed_mps[in] The new speed for the agent in meters/second
@@ -99,8 +95,9 @@ class RailCar : public delphyne::Agent {
           nominal_speed(nominal_speed) {}
   } initial_parameters_;
 
-  mutable delphyne::VectorSource<double>* vel_setter_;
+  std::unique_ptr<Diagram> BuildDiagram() const override;
 
+  mutable delphyne::VectorSource<double>* vel_setter_;
   const drake::maliput::api::RoadGeometry& road_geometry_;
 };
 

--- a/src/agents/simple_car.cc
+++ b/src/agents/simple_car.cc
@@ -39,8 +39,8 @@ SimpleCar::SimpleCar(const std::string& name, double x, double y,
                                drake::Vector3<double>::UnitZ()));
 }
 
-std::unique_ptr<Agent::DiagramBundle> SimpleCar::BuildDiagram() const {
-  DiagramBuilder builder(name_);
+std::unique_ptr<Agent::Diagram> SimpleCar::BuildDiagram() const {
+  DiagramBuilder builder(this->name());
 
   /*********************
    * Context
@@ -61,7 +61,7 @@ std::unique_ptr<Agent::DiagramBundle> SimpleCar::BuildDiagram() const {
   SimpleCarSystem* simple_car_system =
       builder.AddSystem(std::make_unique<SimpleCarSystem>(
           context_continuous_state, context_numeric_parameters));
-  simple_car_system->set_name(name_);
+  simple_car_system->set_name(this->name() + "_system");
 
   /*********************
    * Teleop Systems
@@ -89,7 +89,7 @@ std::unique_ptr<Agent::DiagramBundle> SimpleCar::BuildDiagram() const {
   builder.ExportPoseOutput(simple_car_system->pose_output());
   builder.ExportVelocityOutput(simple_car_system->velocity_output());
 
-  return std::move(builder.Build());
+  return builder.Build();
 }
 
 /*****************************************************************************

--- a/src/agents/simple_car.h
+++ b/src/agents/simple_car.h
@@ -27,12 +27,10 @@ namespace delphyne {
 *****************************************************************************/
 
 /// @brief A very simple vehicle agent that can be teleoperated.
-class SimpleCar : public delphyne::Agent {
+class SimpleCar : public Agent {
  public:
   SimpleCar(const std::string& name, double x, double y, double heading,
             double speed);
-
-  std::unique_ptr<DiagramBundle> BuildDiagram() const;
 
  private:
   // Container for the agent's initial configuration.
@@ -48,6 +46,8 @@ class SimpleCar : public delphyne::Agent {
     Parameters(double x, double y, double heading, double speed)
         : x(x), y(y), heading(heading), speed(speed) {}
   } initial_parameters_;
+
+  std::unique_ptr<Diagram> BuildDiagram() const override;
 };
 
 /*****************************************************************************

--- a/src/agents/trajectory_agent.cc
+++ b/src/agents/trajectory_agent.cc
@@ -68,8 +68,8 @@ TrajectoryAgent::TrajectoryAgent(
       initial_car_pose_velocity.rotation();
 }
 
-std::unique_ptr<Agent::DiagramBundle> TrajectoryAgent::BuildDiagram() const {
-  DiagramBuilder builder(name_);
+std::unique_ptr<Agent::Diagram> TrajectoryAgent::BuildDiagram() const {
+  DiagramBuilder builder(this->name());
 
   /******************************************
    * Trajectory Follower System
@@ -81,7 +81,7 @@ std::unique_ptr<Agent::DiagramBundle> TrajectoryAgent::BuildDiagram() const {
   typedef drake::automotive::TrajectoryFollower<double> TrajectoryFollower;
   TrajectoryFollower* trajectory_follower_system = builder.AddSystem(
       std::make_unique<TrajectoryFollower>(*trajectory_, sampling_time));
-  trajectory_follower_system->set_name(name_);
+  trajectory_follower_system->set_name(this->name() + "_system");
 
   /*********************
    * Diagram Outputs
@@ -90,7 +90,7 @@ std::unique_ptr<Agent::DiagramBundle> TrajectoryAgent::BuildDiagram() const {
   builder.ExportPoseOutput(trajectory_follower_system->pose_output());
   builder.ExportVelocityOutput(trajectory_follower_system->velocity_output());
 
-  return std::move(builder.Build());
+  return builder.Build();
 }
 
 /*****************************************************************************

--- a/src/agents/trajectory_agent.h
+++ b/src/agents/trajectory_agent.h
@@ -28,15 +28,15 @@ namespace delphyne {
  *****************************************************************************/
 
 /// @brief Trajectory following agents
-class TrajectoryAgent : public delphyne::Agent {
+class TrajectoryAgent : public Agent {
  public:
   TrajectoryAgent(const std::string& name, const std::vector<double>& times,
                   const std::vector<double>& headings,
                   const std::vector<std::vector<double>>& translations);
 
-  std::unique_ptr<DiagramBundle> BuildDiagram() const;
-
  private:
+  std::unique_ptr<Diagram> BuildDiagram() const override;
+
   const double initial_time_{};
   std::unique_ptr<drake::automotive::Trajectory> trajectory_{};
 };

--- a/src/backend/automotive_simulator.cc
+++ b/src/backend/automotive_simulator.cc
@@ -48,6 +48,9 @@ using drake::systems::RungeKutta2Integrator;
 using drake::systems::SystemOutput;
 
 template <typename T>
+constexpr double AutomotiveSimulator<T>::kSceneTreePublishRateHz;
+
+template <typename T>
 AutomotiveSimulator<T>::AutomotiveSimulator() {
 // Avoid the many & varied 'info' level logging messages coming from drake.
 //
@@ -113,35 +116,33 @@ std::unique_ptr<ignition::msgs::Scene> AutomotiveSimulator<T>::GetScene() {
 }
 
 template <typename T>
-delphyne::AgentBase<T>* AutomotiveSimulator<T>::AddAgent(
+AgentBase<T>* AutomotiveSimulator<T>::AddAgent(
     std::unique_ptr<AgentBase<T>> agent) {
   /*********************
    * Checks
    *********************/
   DELPHYNE_VALIDATE(!has_started(), std::runtime_error,
                     "Cannot add an agent to a running simulation");
-  CheckNameUniqueness(agent->name());
 
-  /*********************
-   * Unique ID
-   *********************/
-  int id = unique_system_id_++;
+  const std::string& name = agent->name();
+  DELPHYNE_VALIDATE(agents_.count(name) == 0, std::runtime_error,
+                    "An agent named \"" + name + "\" already exists.");
 
   /*********************
    * Agent Diagram
    *********************/
-  std::unique_ptr<DiagramBundle<T>> bundle = agent->BuildDiagram();
-  drake::systems::Diagram<double>* diagram =
-      builder_->AddSystem(std::move(bundle->diagram));
+  const int id = unique_system_id_++;
+
+  DiagramBundle<T>* agent_diagram = agent->BuildInto(builder_.get());
 
   drake::systems::rendering::PoseVelocityInputPorts<double> ports =
-      aggregator_->AddSinglePoseAndVelocityInput(agent->name(), id);
-  builder_->Connect(diagram->get_output_port(bundle->outputs["pose"]),
+      aggregator_->AddSinglePoseAndVelocityInput(name, id);
+  builder_->Connect(agent_diagram->get_output_port("pose"),
                     ports.pose_input_port);
-  builder_->Connect(diagram->get_output_port(bundle->outputs["velocity"]),
+  builder_->Connect(agent_diagram->get_output_port("velocity"),
                     ports.velocity_input_port);
   builder_->Connect(aggregator_->get_output_port(0),
-                    diagram->get_input_port(bundle->inputs["traffic_poses"]));
+                    agent_diagram->get_input_port("traffic_poses"));
 
   /*********************
    * Agent Visuals
@@ -150,21 +151,21 @@ delphyne::AgentBase<T>* AutomotiveSimulator<T>::AddAgent(
   // We'll need a means of having the agents report what visual they have and
   // hooking that up. Also wondering why visuals are in the drake diagram?
   car_vis_applicator_->AddCarVis(
-      std::make_unique<SimplePriusVis<double>>(id, agent->name()));
+      std::make_unique<SimplePriusVis<double>>(id, name));
+
   /*********************
    * Agent Geometry
    *********************/
   // Wires up the Prius geometry.
   builder_->Connect(
-      diagram->get_output_port(bundle->outputs["pose"]),
-      WirePriusGeometry(agent->name(), agent->initial_world_pose(),
+      agent_diagram->get_output_port("pose"),
+      WirePriusGeometry(name, agent->initial_world_pose(),
                         builder_.get(), scene_graph_,
                         &(agent->mutable_geometry_ids())));
 
   // save a handle to it
-  agents_[id] = std::move(agent);
-
-  return agents_[id].get();
+  agents_[name] = std::move(agent);
+  return agents_[name].get();
 }
 
 template <typename T>
@@ -207,6 +208,22 @@ void AutomotiveSimulator<T>::GenerateAndLoadRoadNetworkUrdf(
       urdf_filepath, drake::multibody::joints::kFixed, tree_.get());
 }
 
+template <typename T>
+const delphyne::AgentBase<T>&
+AutomotiveSimulator<T>::GetAgentByName(const std::string& name) const {
+  DELPHYNE_VALIDATE(agents_.count(name) == 1, std::runtime_error,
+                    "No agent found with the given name.");
+  return *agents_.at(name);
+}
+
+template <typename T>
+delphyne::AgentBase<T>*
+AutomotiveSimulator<T>::GetMutableAgentByName(const std::string& name) {
+  DELPHYNE_VALIDATE(agents_.count(name) == 1, std::runtime_error,
+                    "No agent found with the given name.");
+  return agents_[name].get();
+}
+
 namespace {
 
 // A helper functor to check for a given object source (e.g. a GeometryId)
@@ -227,8 +244,9 @@ struct IsSourceOf {
   // Checks whether the given (agent ID, agent) pair is the source of the
   // associated `object`.
   bool operator()(
-      const std::pair<const int, std::unique_ptr<AgentBase<T>>>& id_agent) {
-    return id_agent.second->is_source_of(object);
+      const std::pair<const std::string,
+      std::unique_ptr<AgentBase<T>>>& name_agent) {
+    return name_agent.second->is_source_of(object);
   }
 
   // Associated object to check the source of.
@@ -238,8 +256,7 @@ struct IsSourceOf {
 }  // namespace
 
 template <typename T>
-const std::vector<std::pair<delphyne::AgentBase<T>*, delphyne::AgentBase<T>*>>
-AutomotiveSimulator<T>::GetCollisions() {
+std::vector<AgentBasePair<T>> AutomotiveSimulator<T>::GetCollisions() const {
   DELPHYNE_VALIDATE(has_started(), std::runtime_error,
                     "Can only get collisions on a running simulation");
   using drake::geometry::GeometryId;
@@ -247,8 +264,7 @@ AutomotiveSimulator<T>::GetCollisions() {
   using drake::geometry::PenetrationAsPointPair;
   const std::vector<PenetrationAsPointPair<T>> collisions =
       scene_query_->GetValue<QueryObject<T>>().ComputePointPairPenetration();
-  std::vector<std::pair<delphyne::AgentBase<T>*, delphyne::AgentBase<T>*>>
-      agents_colliding;
+  std::vector<AgentBasePair<T>> agents_in_collision;
   for (const auto& collision : collisions) {
     const auto it_A = std::find_if(agents_.begin(), agents_.end(),
                                    IsSourceOf<T, GeometryId>(collision.id_A));
@@ -258,10 +274,9 @@ AutomotiveSimulator<T>::GetCollisions() {
                                    IsSourceOf<T, GeometryId>(collision.id_B));
     DELPHYNE_VALIDATE(it_B != agents_.end(), std::runtime_error,
                       "Could not find second agent in list of agents");
-    agents_colliding.emplace_back(agents_[it_A->first].get(),
-                                  agents_[it_B->first].get());
+    agents_in_collision.emplace_back(it_A->second.get(), it_B->second.get());
   }
-  return agents_colliding;
+  return agents_in_collision;
 }
 
 template <typename T>
@@ -428,8 +443,14 @@ void AutomotiveSimulator<T>::Start(double realtime_rate) {
   simulator_->get_mutable_integrator()->set_fixed_step_mode(true);
   simulator_->Initialize();
 
+  // Inject context into agents.
+  drake::systems::Context<T>& context =
+      simulator_->get_mutable_context();
+  for (auto& name_agent : agents_) {
+    name_agent.second->GrabContextFrom(*diagram_, &context);
+  }
   // Enable caching support.
-  simulator_->get_mutable_context().EnableCaching();
+  context.EnableCaching();
 
   // Retrieve SceneGraph query object for later use.
   const drake::systems::OutputPort<T>& scene_query_port =
@@ -449,16 +470,6 @@ void AutomotiveSimulator<T>::StepBy(const T& time_step) {
 template <typename T>
 double AutomotiveSimulator<T>::GetCurrentSimulationTime() const {
   return drake::ExtractDoubleOrThrow(simulator_->get_context().get_time());
-}
-
-template <typename T>
-void AutomotiveSimulator<T>::CheckNameUniqueness(const std::string& name) {
-  for (const auto& agent : agents_) {
-    DELPHYNE_VALIDATE(agent.second->name() != name, std::runtime_error,
-                      "An agent named \"" + name +
-                          "\" already exists. It has id " +
-                          std::to_string(agent.first) + ".");
-  }
 }
 
 template <typename T>

--- a/src/backend/simulation_runner.cc
+++ b/src/backend/simulation_runner.cc
@@ -282,8 +282,7 @@ void SimulatorRunner::RunInteractiveSimulationLoopStep() {
   // is not paused.
   if (collisions_enabled_ && running) {
     // Computes collisions between agents.
-    const std::vector<
-        std::pair<delphyne::AgentBase<double>*, delphyne::AgentBase<double>*>>
+    const std::vector<AgentBasePair<double>>
         agents_in_collision = simulator_->GetCollisions();
     if (!agents_in_collision.empty()) {
       // Pauses simulation if necessary.

--- a/src/backend/simulation_runner.h
+++ b/src/backend/simulation_runner.h
@@ -114,8 +114,7 @@ class SimulatorRunner {
   // @brief On agent collision callback function type.
   // @see AutomotiveSimulator::GetCollisions()
   using CollisionCallback = std::function<void(
-      const std::vector<std::pair<delphyne::AgentBase<double>*,
-                                  delphyne::AgentBase<double>*>>&)>;
+      const std::vector<AgentBasePair<double>>&)>;
 
   /// @brief Default constructor.
   ///

--- a/test/regression/cpp/agent_diagram_builder_test.cc
+++ b/test/regression/cpp/agent_diagram_builder_test.cc
@@ -4,20 +4,10 @@
 
 #include <memory>
 
-//#include <chrono>
-//#include <condition_variable>
-//#include <functional>
-//#include <map>
-//#include <mutex>
-//#include <stdexcept>
-//#include <string>
-//#include <thread>
-
-#include "systems/lane_direction.h"
-
 #include <gtest/gtest.h>
 
 #include "helpers.h"
+#include "systems/lane_direction.h"
 #include "systems/simple_car.h"
 #include "test/test_config.h"
 

--- a/test/regression/cpp/automotive_simulator_test.cc
+++ b/test/regression/cpp/automotive_simulator_test.cc
@@ -154,6 +154,19 @@ TEST_F(AutomotiveSimulatorTest, TestGetScene) {
 TEST_F(AutomotiveSimulatorTest, BasicTest) {
   auto simulator = std::make_unique<AutomotiveSimulator<double>>();
   EXPECT_NE(nullptr, simulator->get_builder());
+
+  auto agent_bob =
+      std::make_unique<delphyne::SimpleCar>("bob", 0.0, 0.0, 0.0, 0.0);
+  simulator->AddAgent(std::move(agent_bob));
+  EXPECT_EQ(simulator->GetAgentByName("bob").name(), "bob");
+
+  auto agent_alice =
+      std::make_unique<delphyne::SimpleCar>("alice", 0.0, 0.0, 0.0, 0.0);
+  simulator->AddAgent(std::move(agent_alice));
+  EXPECT_EQ(simulator->GetAgentByName("alice").name(), "alice");
+
+  // Verifies that passing an unknown agent ID is an error.
+  EXPECT_THROW(simulator->GetAgentByName("agent_x"), std::runtime_error);
 }
 
 // Covers simple-car, Start and StepBy
@@ -278,34 +291,35 @@ TEST_F(AutomotiveSimulatorTest, TestMobilControlledSimpleCar) {
   // +---->  +s, +x  | MOBIL Car |   | Decoy 1 |
   // ---------------------------------------------------------------
 
-  auto mobil = std::make_unique<delphyne::MobilCar>("MOBIL0",
-                                                    true,  // lane_direction,
-                                                    2.0,   // x
-                                                    -2.0,  // y
-                                                    0.0,   // heading
-                                                    10.0,  // velocity
-                                                    *road_geometry);
-  simulator->AddAgent(std::move(mobil));
+  simulator->AddAgent(
+      std::make_unique<delphyne::MobilCar>(
+          "MOBIL0",
+          true,  // lane_direction,
+          2.0,   // x
+          -2.0,  // y
+          0.0,   // heading
+          10.0,  // velocity
+          *road_geometry));
+  
+  simulator->AddAgent(
+      std::make_unique<delphyne::RailCar>(
+          "decoy1", *(road_geometry->junction(0)->segment(0)->lane(0)),
+          true,  // lane_direction,
+          6.0,   // position (m)
+          0.0,   // offset (m)
+          0.0,   // speed (m)
+          0.0,   // nominal_speed (m/s)
+          *road_geometry));
 
-  auto decoy_1 = std::make_unique<delphyne::RailCar>(
-      "decoy1", *(road_geometry->junction(0)->segment(0)->lane(0)),
-      true,  // lane_direction,
-      6.0,   // position (m)
-      0.0,   // offset (m)
-      0.0,   // speed (m)
-      0.0,   // nominal_speed (m/s)
-      *road_geometry);
-  simulator->AddAgent(std::move(decoy_1));
-
-  auto decoy_2 = std::make_unique<delphyne::RailCar>(
-      "decoy2", *(road_geometry->junction(0)->segment(0)->lane(0)),
-      true,  // lane_direction,
-      20.0,  // position (m)
-      0.0,   // offset (m)
-      0.0,   // speed (m/s)
-      0.0,   // nominal_speed (m/s)
-      *road_geometry);
-  simulator->AddAgent(std::move(decoy_2));
+  simulator->AddAgent(
+      std::make_unique<delphyne::RailCar>(
+          "decoy2", *(road_geometry->junction(0)->segment(0)->lane(0)),
+          true,  // lane_direction,
+          20.0,  // position (m)
+          0.0,   // offset (m)
+          0.0,   // speed (m/s)
+          0.0,   // nominal_speed (m/s)
+          *road_geometry));
 
   // Setup an ignition transport topic monitor to listen to
   // ignition::msgs::Model_V messages being published to
@@ -345,11 +359,10 @@ TEST_F(AutomotiveSimulatorTest, TestTrajectoryAgent) {
       {0.0, 0.0, 0.0},  {10.0, 0.0, 0.0},  {30.0, 0.0, 0.0},
       {60.0, 0.0, 0.0}, {100.0, 0.0, 0.0},
   };
-  std::unique_ptr<delphyne::TrajectoryAgent> alice =
-      std::make_unique<delphyne::TrajectoryAgent>("alice", times, headings,
-                                                  translations);
 
-  simulator->AddAgent(std::move(alice));
+  simulator->AddAgent(
+      std::make_unique<delphyne::TrajectoryAgent>(
+          "alice", times, headings, translations));
 
   // Setup an ignition transport topic monitor to listen to
   // ignition::msgs::Model_V messages being published to
@@ -539,7 +552,7 @@ TEST_F(AutomotiveSimulatorTest, TestDuplicateVehicleNameException) {
   EXPECT_NO_THROW(simulator->AddAgent(std::move(agent1)));
   EXPECT_RUNTIME_THROW(
       simulator->AddAgent(std::move(agent2)),
-      "An agent named \"Model1\" already exists. It has id 0.");
+      "An agent named \"Model1\" already exists.");
 
   auto agent_1 = std::make_unique<delphyne::RailCar>(
       "FOO", *(road_geometry->junction(0)->segment(0)->lane(0)),
@@ -570,7 +583,7 @@ TEST_F(AutomotiveSimulatorTest, TestDuplicateVehicleNameException) {
       5.0,   // nominal_speed
       *road_geometry);
   EXPECT_RUNTIME_THROW(simulator->AddAgent(std::move(agent_3)),
-                       "An agent named \"alice\" already exists. It has id 2.");
+                       "An agent named \"alice\" already exists.");
 }
 
 // Verifies that the velocity outputs of the rail cars are connected to
@@ -589,26 +602,25 @@ TEST_F(AutomotiveSimulatorTest, TestRailcarVelocityOutput) {
 
   const double kR{0.5};
 
-  auto alice = std::make_unique<delphyne::RailCar>(
-      "alice", *(road_geometry->junction(0)->segment(0)->lane(0)),
-      true,  // lane_direction,
-      5.0,   // position
-      kR,    // offset
-      1.0,   // speed
-      5.0,   // nominal_speed
-      *road_geometry);
+  auto alice = simulator->AddAgent(
+      std::make_unique<delphyne::RailCar>(
+          "alice", *(road_geometry->junction(0)->segment(0)->lane(0)),
+          true,  // lane_direction,
+          5.0,   // position
+          kR,    // offset
+          1.0,   // speed
+          5.0,   // nominal_speed
+          *road_geometry));
 
-  auto bob = std::make_unique<delphyne::RailCar>(
-      "bob", *(road_geometry->junction(0)->segment(0)->lane(0)),
-      true,  // lane_direction,
-      0.0,   // position
-      kR,    // offset
-      0.0,   // speed
-      0.0,   // nominal_speed
-      *road_geometry);
-
-  simulator->AddAgent(std::move(alice));
-  simulator->AddAgent(std::move(bob));
+  auto bob = simulator->AddAgent(
+      std::make_unique<delphyne::RailCar>(
+          "bob", *(road_geometry->junction(0)->segment(0)->lane(0)),
+          true,  // lane_direction,
+          0.0,   // position
+          kR,    // offset
+          0.0,   // speed
+          0.0,   // nominal_speed
+          *road_geometry));
 
   EXPECT_NO_THROW(simulator->Start());
 
@@ -624,8 +636,11 @@ TEST_F(AutomotiveSimulatorTest, TestRailcarVelocityOutput) {
   const drake::systems::rendering::PoseBundle<double> poses =
       simulator->GetCurrentPoses();
   ASSERT_EQ(poses.get_num_poses(), 2);
+
   ASSERT_EQ(poses.get_model_instance_id(kAliceIndex), 0);
   ASSERT_EQ(poses.get_model_instance_id(kBobIndex), 1);
+  ASSERT_EQ(poses.get_name(kAliceIndex), alice->name());
+  ASSERT_EQ(poses.get_name(kBobIndex), bob->name());
   EXPECT_FALSE(poses.get_velocity(kAliceIndex).get_value().isZero());
   EXPECT_TRUE(poses.get_velocity(kBobIndex).get_value().isZero());
 }
@@ -728,32 +743,31 @@ TEST_F(AutomotiveSimulatorTest, TestGetCollisions) {
       second_lane->length(), kZeroROffset, kZeroHOffset};
   const drake::maliput::api::GeoPosition agent_alice_geo_position =
       second_lane->ToGeoPosition(agent_alice_lane_position);
-  auto agent_alice = std::make_unique<delphyne::SimpleCar>(
-      "alice", agent_alice_geo_position.x(), agent_alice_geo_position.y(),
-      kHeadingWest, kCruiseSpeed);
-  delphyne::AgentBase<double>* alice_ptr =
-      simulator->AddAgent(std::move(agent_alice));
+
+  auto agent_alice = simulator->AddAgent(
+      std::make_unique<delphyne::SimpleCar>(
+          "alice", agent_alice_geo_position.x(),
+          agent_alice_geo_position.y(),
+          kHeadingWest, kCruiseSpeed));
 
   // Configures agent `Smith`.
   const drake::maliput::api::LanePosition agent_smith_lane_position{
       kZeroSOffset, kZeroROffset, kZeroHOffset};
   const drake::maliput::api::GeoPosition agent_smith_geo_position =
       first_lane->ToGeoPosition(agent_smith_lane_position);
-  auto agent_smith = std::make_unique<delphyne::SimpleCar>(
-      "smith", agent_smith_geo_position.x(), agent_smith_geo_position.y(),
-      kHeadingEast + kHeadingDeviation, kCruiseSpeed);
-  delphyne::AgentBase<double>* smith_ptr =
-      simulator->AddAgent(std::move(agent_smith));
+  auto agent_smith =
+      simulator->AddAgent(std::make_unique<delphyne::SimpleCar>(
+          "smith", agent_smith_geo_position.x(), agent_smith_geo_position.y(),
+          kHeadingEast + kHeadingDeviation, kCruiseSpeed));
 
   // Finishes initialization and starts the simulation.
   simulator->Start();
 
   // Verifies that no agent is in collision at the beginning
   // of the simulation.
-  std::vector<
-      std::pair<delphyne::AgentBase<double>*, delphyne::AgentBase<double>*>>
-      agent_pairs_in_collision = simulator->GetCollisions();
-  EXPECT_EQ(agent_pairs_in_collision.size(), 0);
+  std::vector<AgentBasePair<double>>
+      agents_in_collision = simulator->GetCollisions();
+  EXPECT_EQ(agents_in_collision.size(), 0);
 
   // Simulates forward in time.
   const double kTimeToCollision{5.};  // in sec
@@ -761,15 +775,18 @@ TEST_F(AutomotiveSimulatorTest, TestGetCollisions) {
 
   // Checks that there was a collision and that the colliding
   // agents are the expected ones.
-  agent_pairs_in_collision = simulator->GetCollisions();
-  EXPECT_EQ(agent_pairs_in_collision.size(), 1);
+  agents_in_collision = simulator->GetCollisions();
+  EXPECT_EQ(agents_in_collision.size(), 1);
 
-  delphyne::AgentBase<double>* coll1_ptr = agent_pairs_in_collision[0].first;
-  delphyne::AgentBase<double>* coll2_ptr = agent_pairs_in_collision[0].second;
+  const AgentBasePair<double>& colliding_agents = agents_in_collision.front();
+  const AgentBase<double>* first_colliding_agent = colliding_agents.first;
+  const AgentBase<double>* second_colliding_agent = colliding_agents.second;
   // Cannot make any assumption regarding pair order, see
   // delphyne::AutomotiveSimulator::GetCollisions().
-  EXPECT_TRUE((coll1_ptr == alice_ptr && coll2_ptr == smith_ptr) ||
-              (coll1_ptr == smith_ptr && coll2_ptr == alice_ptr));
+  EXPECT_TRUE((first_colliding_agent == agent_alice &&
+               second_colliding_agent == agent_smith) ||
+              (first_colliding_agent == agent_smith &&
+               second_colliding_agent == agent_alice));
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
Closes #549. Based on #508, this pull request changes the way `Agent`s interoperate with the `AutomotiveSimulator`, such that `Agent`s can get hold of both their `Diagram` and `Context`. This enables us to implement a basic common API. This API is then used by the `delphyne-crash` demo to provide the location and velocity of the colliding agents.

