### PR TITLE
Port remaining automotive code

### DIFF
--- a/src/gen/bicycle_car_parameters.cc
+++ b/src/gen/bicycle_car_parameters.cc
@@ -1,0 +1,32 @@
+// Copyright 2018 Toyota Research Institute
+
+#include "gen/bicycle_car_parameters.h"
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+namespace delphyne {
+
+const int BicycleCarParametersIndices::kNumCoordinates;
+const int BicycleCarParametersIndices::kMass;
+const int BicycleCarParametersIndices::kLf;
+const int BicycleCarParametersIndices::kLr;
+const int BicycleCarParametersIndices::kIz;
+const int BicycleCarParametersIndices::kCf;
+const int BicycleCarParametersIndices::kCr;
+
+const std::vector<std::string>&
+BicycleCarParametersIndices::GetCoordinateNames() {
+  static const drake::never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "mass",  // BR
+          "lf",    // BR
+          "lr",    // BR
+          "Iz",    // BR
+          "Cf",    // BR
+          "Cr",    // BR
+      });
+  return coordinates.access();
+}
+
+}  // namespace delphyne

--- a/src/gen/bicycle_car_parameters.h
+++ b/src/gen/bicycle_car_parameters.h
@@ -1,0 +1,154 @@
+// Copyright 2018 Toyota Research Institute
+
+#pragma once
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+
+#include <drake/common/drake_bool.h>
+#include <drake/common/dummy_value.h>
+#include <drake/common/never_destroyed.h>
+#include <drake/common/symbolic.h>
+#include <drake/systems/framework/basic_vector.h>
+
+namespace delphyne {
+
+/// Describes the row indices of a BicycleCarParameters.
+struct BicycleCarParametersIndices {
+  /// The total number of rows (coordinates).
+  static const int kNumCoordinates = 6;
+
+  // The index of each individual coordinate.
+  static const int kMass = 0;
+  static const int kLf = 1;
+  static const int kLr = 2;
+  static const int kIz = 3;
+  static const int kCf = 4;
+  static const int kCr = 5;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `BicycleCarParametersIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
+};
+
+/// Specializes BasicVector with specific getters and setters.
+template <typename T>
+class BicycleCarParameters final : public drake::systems::BasicVector<T> {
+ public:
+  /// An abbreviation for our row index constants.
+  typedef BicycleCarParametersIndices K;
+
+  /// Default constructor.  Sets all rows to their default value:
+  /// @arg @c mass defaults to 2278.0 kg.
+  /// @arg @c lf defaults to 1.292 m.
+  /// @arg @c lr defaults to 1.515 m.
+  /// @arg @c Iz defaults to 3210.0 kg m^2.
+  /// @arg @c Cf defaults to 10.8e4 N / rad.
+  /// @arg @c Cr defaults to 10.8e4 N / rad.
+  BicycleCarParameters() : drake::systems::BasicVector<T>(K::kNumCoordinates) {
+    this->set_mass(2278.0);
+    this->set_lf(1.292);
+    this->set_lr(1.515);
+    this->set_Iz(3210.0);
+    this->set_Cf(10.8e4);
+    this->set_Cr(10.8e4);
+  }
+
+  /// Create a symbolic::Variable for each element with the known variable
+  /// name.  This is only available for T == symbolic::Expression.
+  template <typename U = T>
+  typename std::enable_if<
+      std::is_same<U, drake::symbolic::Expression>::value>::type
+  SetToNamedVariables() {
+    this->set_mass(drake::symbolic::Variable("mass"));
+    this->set_lf(drake::symbolic::Variable("lf"));
+    this->set_lr(drake::symbolic::Variable("lr"));
+    this->set_Iz(drake::symbolic::Variable("Iz"));
+    this->set_Cf(drake::symbolic::Variable("Cf"));
+    this->set_Cr(drake::symbolic::Variable("Cr"));
+  }
+
+  BicycleCarParameters<T>* DoClone() const final {
+    return new BicycleCarParameters;
+  }
+
+  /// @name Getters and Setters
+  //@{
+  /// mass
+  /// @note @c mass is expressed in units of kg.
+  /// @note @c mass has a limited domain of [0.0, +Inf].
+  const T& mass() const { return this->GetAtIndex(K::kMass); }
+  void set_mass(const T& mass) { this->SetAtIndex(K::kMass, mass); }
+  /// distance from the center of mass to the front axle
+  /// @note @c lf is expressed in units of m.
+  /// @note @c lf has a limited domain of [0.0, +Inf].
+  const T& lf() const { return this->GetAtIndex(K::kLf); }
+  void set_lf(const T& lf) { this->SetAtIndex(K::kLf, lf); }
+  /// distance from the center of mass to the rear axle
+  /// @note @c lr is expressed in units of m.
+  /// @note @c lr has a limited domain of [0.0, +Inf].
+  const T& lr() const { return this->GetAtIndex(K::kLr); }
+  void set_lr(const T& lr) { this->SetAtIndex(K::kLr, lr); }
+  /// moment of inertia about the yaw-axis
+  /// @note @c Iz is expressed in units of kg m^2.
+  /// @note @c Iz has a limited domain of [0.0, +Inf].
+  const T& Iz() const { return this->GetAtIndex(K::kIz); }
+  void set_Iz(const T& Iz) { this->SetAtIndex(K::kIz, Iz); }
+  /// cornering stiffness (front)
+  /// @note @c Cf is expressed in units of N / rad.
+  /// @note @c Cf has a limited domain of [0.0, +Inf].
+  const T& Cf() const { return this->GetAtIndex(K::kCf); }
+  void set_Cf(const T& Cf) { this->SetAtIndex(K::kCf, Cf); }
+  /// cornering stiffness (rear)
+  /// @note @c Cr is expressed in units of N / rad.
+  /// @note @c Cr has a limited domain of [0.0, +Inf].
+  const T& Cr() const { return this->GetAtIndex(K::kCr); }
+  void set_Cr(const T& Cr) { this->SetAtIndex(K::kCr, Cr); }
+  //@}
+
+  /// See BicycleCarParametersIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return BicycleCarParametersIndices::GetCoordinateNames();
+  }
+
+  /// Returns whether the current values of this vector are well-formed.
+  drake::scalar_predicate_t<T> IsValid() const {
+    using std::isnan;
+    drake::scalar_predicate_t<T> result{true};
+    result = result && !isnan(mass());
+    result = result && (mass() >= T(0.0));
+    result = result && !isnan(lf());
+    result = result && (lf() >= T(0.0));
+    result = result && !isnan(lr());
+    result = result && (lr() >= T(0.0));
+    result = result && !isnan(Iz());
+    result = result && (Iz() >= T(0.0));
+    result = result && !isnan(Cf());
+    result = result && (Cf() >= T(0.0));
+    result = result && !isnan(Cr());
+    result = result && (Cr() >= T(0.0));
+    return result;
+  }
+
+  // VectorBase override.
+  void CalcInequalityConstraint(drake::VectorX<T>* value) const final {
+    value->resize(6);
+    (*value)[0] = mass() - T(0.0);
+    (*value)[1] = lf() - T(0.0);
+    (*value)[2] = lr() - T(0.0);
+    (*value)[3] = Iz() - T(0.0);
+    (*value)[4] = Cf() - T(0.0);
+    (*value)[5] = Cr() - T(0.0);
+  }
+};
+
+}  // namespace delphyne

--- a/src/gen/bicycle_car_state.cc
+++ b/src/gen/bicycle_car_state.cc
@@ -1,0 +1,31 @@
+// Copyright 2018 Toyota Research Institute
+
+#include "gen/bicycle_car_state.h"
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+namespace delphyne {
+
+const int BicycleCarStateIndices::kNumCoordinates;
+const int BicycleCarStateIndices::kPsi;
+const int BicycleCarStateIndices::kPsiDot;
+const int BicycleCarStateIndices::kBeta;
+const int BicycleCarStateIndices::kVel;
+const int BicycleCarStateIndices::kSx;
+const int BicycleCarStateIndices::kSy;
+
+const std::vector<std::string>& BicycleCarStateIndices::GetCoordinateNames() {
+  static const drake::never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "Psi",      // BR
+          "Psi_dot",  // BR
+          "beta",     // BR
+          "vel",      // BR
+          "sx",       // BR
+          "sy",       // BR
+      });
+  return coordinates.access();
+}
+
+}  // namespace delphyne

--- a/src/gen/bicycle_car_state.h
+++ b/src/gen/bicycle_car_state.h
@@ -1,0 +1,123 @@
+// Copyright 2018 Toyota Research Institute
+
+#pragma once
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+
+#include <drake/common/drake_bool.h>
+#include <drake/common/dummy_value.h>
+#include <drake/common/never_destroyed.h>
+#include <drake/common/symbolic.h>
+#include <drake/systems/framework/basic_vector.h>
+
+namespace delphyne {
+
+/// Describes the row indices of a BicycleCarState.
+struct BicycleCarStateIndices {
+  /// The total number of rows (coordinates).
+  static const int kNumCoordinates = 6;
+
+  // The index of each individual coordinate.
+  static const int kPsi = 0;
+  static const int kPsiDot = 1;
+  static const int kBeta = 2;
+  static const int kVel = 3;
+  static const int kSx = 4;
+  static const int kSy = 5;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `BicycleCarStateIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
+};
+
+/// Specializes BasicVector with specific getters and setters.
+template <typename T>
+class BicycleCarState final : public drake::systems::BasicVector<T> {
+ public:
+  /// An abbreviation for our row index constants.
+  typedef BicycleCarStateIndices K;
+
+  /// Default constructor.  Sets all rows to their default value:
+  /// @arg @c Psi defaults to 0.0 with unknown units.
+  /// @arg @c Psi_dot defaults to 0.0 with unknown units.
+  /// @arg @c beta defaults to 0.0 with unknown units.
+  /// @arg @c vel defaults to 0.0 with unknown units.
+  /// @arg @c sx defaults to 0.0 with unknown units.
+  /// @arg @c sy defaults to 0.0 with unknown units.
+  BicycleCarState() : drake::systems::BasicVector<T>(K::kNumCoordinates) {
+    this->set_Psi(0.0);
+    this->set_Psi_dot(0.0);
+    this->set_beta(0.0);
+    this->set_vel(0.0);
+    this->set_sx(0.0);
+    this->set_sy(0.0);
+  }
+
+  /// Create a symbolic::Variable for each element with the known variable
+  /// name.  This is only available for T == symbolic::Expression.
+  template <typename U = T>
+  typename std::enable_if<
+      std::is_same<U, drake::symbolic::Expression>::value>::type
+  SetToNamedVariables() {
+    this->set_Psi(drake::symbolic::Variable("Psi"));
+    this->set_Psi_dot(drake::symbolic::Variable("Psi_dot"));
+    this->set_beta(drake::symbolic::Variable("beta"));
+    this->set_vel(drake::symbolic::Variable("vel"));
+    this->set_sx(drake::symbolic::Variable("sx"));
+    this->set_sy(drake::symbolic::Variable("sy"));
+  }
+
+  BicycleCarState<T>* DoClone() const final { return new BicycleCarState; }
+
+  /// @name Getters and Setters
+  //@{
+  /// yaw angle
+  const T& Psi() const { return this->GetAtIndex(K::kPsi); }
+  void set_Psi(const T& Psi) { this->SetAtIndex(K::kPsi, Psi); }
+  /// yaw angular rate
+  const T& Psi_dot() const { return this->GetAtIndex(K::kPsiDot); }
+  void set_Psi_dot(const T& Psi_dot) { this->SetAtIndex(K::kPsiDot, Psi_dot); }
+  /// slip angle at the center of mass
+  const T& beta() const { return this->GetAtIndex(K::kBeta); }
+  void set_beta(const T& beta) { this->SetAtIndex(K::kBeta, beta); }
+  /// velocity magnitude
+  const T& vel() const { return this->GetAtIndex(K::kVel); }
+  void set_vel(const T& vel) { this->SetAtIndex(K::kVel, vel); }
+  /// x-position at the center of mass
+  const T& sx() const { return this->GetAtIndex(K::kSx); }
+  void set_sx(const T& sx) { this->SetAtIndex(K::kSx, sx); }
+  /// y-position at the center of mass
+  const T& sy() const { return this->GetAtIndex(K::kSy); }
+  void set_sy(const T& sy) { this->SetAtIndex(K::kSy, sy); }
+  //@}
+
+  /// See BicycleCarStateIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return BicycleCarStateIndices::GetCoordinateNames();
+  }
+
+  /// Returns whether the current values of this vector are well-formed.
+  drake::scalar_predicate_t<T> IsValid() const {
+    using std::isnan;
+    drake::scalar_predicate_t<T> result{true};
+    result = result && !isnan(Psi());
+    result = result && !isnan(Psi_dot());
+    result = result && !isnan(beta());
+    result = result && !isnan(vel());
+    result = result && !isnan(sx());
+    result = result && !isnan(sy());
+    return result;
+  }
+};
+
+}  // namespace delphyne

--- a/src/gen/dynamic_bicycle_car_input.cc
+++ b/src/gen/dynamic_bicycle_car_input.cc
@@ -1,0 +1,24 @@
+// Copyright 2018 Toyota Research Institute
+
+#include "gen/dynamic_bicycle_car_input.h"
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+namespace delphyne {
+
+const int DynamicBicycleCarInputIndices::kNumCoordinates;
+const int DynamicBicycleCarInputIndices::kSteerCd;
+const int DynamicBicycleCarInputIndices::kFCpX;
+
+const std::vector<std::string>&
+DynamicBicycleCarInputIndices::GetCoordinateNames() {
+  static const drake::never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "steer_CD",  // BR
+          "f_Cp_x",    // BR
+      });
+  return coordinates.access();
+}
+
+}  // namespace delphyne

--- a/src/gen/dynamic_bicycle_car_input.h
+++ b/src/gen/dynamic_bicycle_car_input.h
@@ -1,0 +1,99 @@
+// Copyright 2018 Toyota Research Institute
+
+#pragma once
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+
+#include <drake/common/drake_bool.h>
+#include <drake/common/dummy_value.h>
+#include <drake/common/never_destroyed.h>
+#include <drake/common/symbolic.h>
+#include <drake/systems/framework/basic_vector.h>
+
+namespace delphyne {
+
+/// Describes the row indices of a DynamicBicycleCarInput.
+struct DynamicBicycleCarInputIndices {
+  /// The total number of rows (coordinates).
+  static const int kNumCoordinates = 2;
+
+  // The index of each individual coordinate.
+  static const int kSteerCd = 0;
+  static const int kFCpX = 1;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `DynamicBicycleCarInputIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
+};
+
+/// Specializes BasicVector with specific getters and setters.
+template <typename T>
+class DynamicBicycleCarInput final : public drake::systems::BasicVector<T> {
+ public:
+  /// An abbreviation for our row index constants.
+  typedef DynamicBicycleCarInputIndices K;
+
+  /// Default constructor.  Sets all rows to their default value:
+  /// @arg @c steer_CD defaults to 0.0 rad.
+  /// @arg @c f_Cp_x defaults to 0.0 N.
+  DynamicBicycleCarInput()
+      : drake::systems::BasicVector<T>(K::kNumCoordinates) {
+    this->set_steer_CD(0.0);
+    this->set_f_Cp_x(0.0);
+  }
+
+  /// Create a drake::symbolic::Variable for each element with the known
+  /// variable
+  /// name.  This is only available for T == drake::symbolic::Expression.
+  template <typename U = T>
+  typename std::enable_if<
+      std::is_same<U, drake::symbolic::Expression>::value>::type
+  SetToNamedVariables() {
+    this->set_steer_CD(drake::symbolic::Variable("steer_CD"));
+    this->set_f_Cp_x(drake::symbolic::Variable("f_Cp_x"));
+  }
+
+  DynamicBicycleCarInput<T>* DoClone() const final {
+    return new DynamicBicycleCarInput;
+  }
+
+  /// @name Getters and Setters
+  //@{
+  /// Steer angle from Cx to Dx with positive Cz sense.
+  /// @note @c steer_CD is expressed in units of rad.
+  const T& steer_CD() const { return this->GetAtIndex(K::kSteerCd); }
+  void set_steer_CD(const T& steer_CD) {
+    this->SetAtIndex(K::kSteerCd, steer_CD);
+  }
+  /// The Cx measure of the Longitudinal force on body C at Cp.
+  /// @note @c f_Cp_x is expressed in units of N.
+  const T& f_Cp_x() const { return this->GetAtIndex(K::kFCpX); }
+  void set_f_Cp_x(const T& f_Cp_x) { this->SetAtIndex(K::kFCpX, f_Cp_x); }
+  //@}
+
+  /// See DynamicBicycleCarInputIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return DynamicBicycleCarInputIndices::GetCoordinateNames();
+  }
+
+  /// Returns whether the current values of this vector are well-formed.
+  drake::scalar_predicate_t<T> IsValid() const {
+    using std::isnan;
+    drake::scalar_predicate_t<T> result{true};
+    result = result && !isnan(steer_CD());
+    result = result && !isnan(f_Cp_x());
+    return result;
+  }
+};
+
+}  // namespace delphyne

--- a/src/gen/dynamic_bicycle_car_params.cc
+++ b/src/gen/dynamic_bicycle_car_params.cc
@@ -1,0 +1,38 @@
+// Copyright 2018 Toyota Research Institute
+
+#include "gen/dynamic_bicycle_car_params.h"
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+namespace delphyne {
+
+const int DynamicBicycleCarParamsIndices::kNumCoordinates;
+const int DynamicBicycleCarParamsIndices::kMass;
+const int DynamicBicycleCarParamsIndices::kIzz;
+const int DynamicBicycleCarParamsIndices::kCAlphaF;
+const int DynamicBicycleCarParamsIndices::kCAlphaR;
+const int DynamicBicycleCarParamsIndices::kMu;
+const int DynamicBicycleCarParamsIndices::kLf;
+const int DynamicBicycleCarParamsIndices::kLb;
+const int DynamicBicycleCarParamsIndices::kPLocpZ;
+const int DynamicBicycleCarParamsIndices::kGravity;
+
+const std::vector<std::string>&
+DynamicBicycleCarParamsIndices::GetCoordinateNames() {
+  static const drake::never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "mass",       // BR
+          "izz",        // BR
+          "c_alpha_f",  // BR
+          "c_alpha_r",  // BR
+          "mu",         // BR
+          "Lf",         // BR
+          "Lb",         // BR
+          "p_LoCp_z",   // BR
+          "gravity",    // BR
+      });
+  return coordinates.access();
+}
+
+}  // namespace delphyne

--- a/src/gen/dynamic_bicycle_car_params.h
+++ b/src/gen/dynamic_bicycle_car_params.h
@@ -1,0 +1,198 @@
+// Copyright 2018 Toyota Research Institute
+
+#pragma once
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+
+#include <drake/common/drake_bool.h>
+#include <drake/common/dummy_value.h>
+#include <drake/common/never_destroyed.h>
+#include <drake/common/symbolic.h>
+#include <drake/systems/framework/basic_vector.h>
+
+namespace delphyne {
+
+/// Describes the row indices of a DynamicBicycleCarParams.
+struct DynamicBicycleCarParamsIndices {
+  /// The total number of rows (coordinates).
+  static const int kNumCoordinates = 9;
+
+  // The index of each individual coordinate.
+  static const int kMass = 0;
+  static const int kIzz = 1;
+  static const int kCAlphaF = 2;
+  static const int kCAlphaR = 3;
+  static const int kMu = 4;
+  static const int kLf = 5;
+  static const int kLb = 6;
+  static const int kPLocpZ = 7;
+  static const int kGravity = 8;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `DynamicBicycleCarParamsIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
+};
+
+/// Specializes BasicVector with specific getters and setters.
+template <typename T>
+class DynamicBicycleCarParams final : public drake::systems::BasicVector<T> {
+ public:
+  /// An abbreviation for our row index constants.
+  typedef DynamicBicycleCarParamsIndices K;
+
+  /// Default constructor.  Sets all rows to their default value:
+  /// @arg @c mass defaults to 1823.0 kg.
+  /// @arg @c izz defaults to 2000.0 kgm^2.
+  /// @arg @c c_alpha_f defaults to 115000 N/rad.
+  /// @arg @c c_alpha_r defaults to 155000 N/rad.
+  /// @arg @c mu defaults to 0.55 dimensionless.
+  /// @arg @c Lf defaults to 1.54 m.
+  /// @arg @c Lb defaults to 1.21 m.
+  /// @arg @c p_LoCp_z defaults to 0.508 m.
+  /// @arg @c gravity defaults to 9.81 m/s^2.
+  DynamicBicycleCarParams()
+      : drake::systems::BasicVector<T>(K::kNumCoordinates) {
+    this->set_mass(1823.0);
+    this->set_izz(2000.0);
+    this->set_c_alpha_f(115000);
+    this->set_c_alpha_r(155000);
+    this->set_mu(0.55);
+    this->set_Lf(1.54);
+    this->set_Lb(1.21);
+    this->set_p_LoCp_z(0.508);
+    this->set_gravity(9.81);
+  }
+
+  /// Create a drake::symbolic::Variable for each element with the known
+  /// variable
+  /// name.  This is only available for T == drake::symbolic::Expression.
+  template <typename U = T>
+  typename std::enable_if<
+      std::is_same<U, drake::symbolic::Expression>::value>::type
+  SetToNamedVariables() {
+    this->set_mass(drake::symbolic::Variable("mass"));
+    this->set_izz(drake::symbolic::Variable("izz"));
+    this->set_c_alpha_f(drake::symbolic::Variable("c_alpha_f"));
+    this->set_c_alpha_r(drake::symbolic::Variable("c_alpha_r"));
+    this->set_mu(drake::symbolic::Variable("mu"));
+    this->set_Lf(drake::symbolic::Variable("Lf"));
+    this->set_Lb(drake::symbolic::Variable("Lb"));
+    this->set_p_LoCp_z(drake::symbolic::Variable("p_LoCp_z"));
+    this->set_gravity(drake::symbolic::Variable("gravity"));
+  }
+
+  DynamicBicycleCarParams<T>* DoClone() const final {
+    return new DynamicBicycleCarParams;
+  }
+
+  /// @name Getters and Setters
+  //@{
+  /// Mass of X1 vehicle.
+  /// @note @c mass is expressed in units of kg.
+  /// @note @c mass has a limited domain of [0.0, +Inf].
+  const T& mass() const { return this->GetAtIndex(K::kMass); }
+  void set_mass(const T& mass) { this->SetAtIndex(K::kMass, mass); }
+  /// moment of inertia.
+  /// @note @c izz is expressed in units of kgm^2.
+  /// @note @c izz has a limited domain of [0.0, +Inf].
+  const T& izz() const { return this->GetAtIndex(K::kIzz); }
+  void set_izz(const T& izz) { this->SetAtIndex(K::kIzz, izz); }
+  /// Front cornering stiffness.
+  /// @note @c c_alpha_f is expressed in units of N/rad.
+  /// @note @c c_alpha_f has a limited domain of [0.0, +Inf].
+  const T& c_alpha_f() const { return this->GetAtIndex(K::kCAlphaF); }
+  void set_c_alpha_f(const T& c_alpha_f) {
+    this->SetAtIndex(K::kCAlphaF, c_alpha_f);
+  }
+  /// Rear cornering stiffness.
+  /// @note @c c_alpha_r is expressed in units of N/rad.
+  /// @note @c c_alpha_r has a limited domain of [0.0, +Inf].
+  const T& c_alpha_r() const { return this->GetAtIndex(K::kCAlphaR); }
+  void set_c_alpha_r(const T& c_alpha_r) {
+    this->SetAtIndex(K::kCAlphaR, c_alpha_r);
+  }
+  /// Coefficient of friction between tire and road surface.
+  /// @note @c mu is expressed in units of dimensionless.
+  /// @note @c mu has a limited domain of [0.0, +Inf].
+  const T& mu() const { return this->GetAtIndex(K::kMu); }
+  void set_mu(const T& mu) { this->SetAtIndex(K::kMu, mu); }
+  /// Distance from control point to front axle (referred to as 'a' in Bobier).
+  /// @note @c Lf is expressed in units of m.
+  /// @note @c Lf has a limited domain of [0.0, +Inf].
+  const T& Lf() const { return this->GetAtIndex(K::kLf); }
+  void set_Lf(const T& Lf) { this->SetAtIndex(K::kLf, Lf); }
+  /// Distance from rear axle to control point (referred to as 'b' in Bobier).
+  /// @note @c Lb is expressed in units of m.
+  /// @note @c Lb has a limited domain of [0.0, +Inf].
+  const T& Lb() const { return this->GetAtIndex(K::kLb); }
+  void set_Lb(const T& Lb) { this->SetAtIndex(K::kLb, Lb); }
+  /// Height of vehicle's control point Cp.
+  /// @note @c p_LoCp_z is expressed in units of m.
+  /// @note @c p_LoCp_z has a limited domain of [0.0, +Inf].
+  const T& p_LoCp_z() const { return this->GetAtIndex(K::kPLocpZ); }
+  void set_p_LoCp_z(const T& p_LoCp_z) {
+    this->SetAtIndex(K::kPLocpZ, p_LoCp_z);
+  }
+  /// An approximate value for gravitational acceleration.
+  /// @note @c gravity is expressed in units of m/s^2.
+  /// @note @c gravity has a limited domain of [0.0, +Inf].
+  const T& gravity() const { return this->GetAtIndex(K::kGravity); }
+  void set_gravity(const T& gravity) { this->SetAtIndex(K::kGravity, gravity); }
+  //@}
+
+  /// See DynamicBicycleCarParamsIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return DynamicBicycleCarParamsIndices::GetCoordinateNames();
+  }
+
+  /// Returns whether the current values of this vector are well-formed.
+  drake::scalar_predicate_t<T> IsValid() const {
+    using std::isnan;
+    drake::scalar_predicate_t<T> result{true};
+    result = result && !isnan(mass());
+    result = result && (mass() >= T(0.0));
+    result = result && !isnan(izz());
+    result = result && (izz() >= T(0.0));
+    result = result && !isnan(c_alpha_f());
+    result = result && (c_alpha_f() >= T(0.0));
+    result = result && !isnan(c_alpha_r());
+    result = result && (c_alpha_r() >= T(0.0));
+    result = result && !isnan(mu());
+    result = result && (mu() >= T(0.0));
+    result = result && !isnan(Lf());
+    result = result && (Lf() >= T(0.0));
+    result = result && !isnan(Lb());
+    result = result && (Lb() >= T(0.0));
+    result = result && !isnan(p_LoCp_z());
+    result = result && (p_LoCp_z() >= T(0.0));
+    result = result && !isnan(gravity());
+    result = result && (gravity() >= T(0.0));
+    return result;
+  }
+
+  // VectorBase override.
+  void CalcInequalityConstraint(drake::VectorX<T>* value) const final {
+    value->resize(9);
+    (*value)[0] = mass() - T(0.0);
+    (*value)[1] = izz() - T(0.0);
+    (*value)[2] = c_alpha_f() - T(0.0);
+    (*value)[3] = c_alpha_r() - T(0.0);
+    (*value)[4] = mu() - T(0.0);
+    (*value)[5] = Lf() - T(0.0);
+    (*value)[6] = Lb() - T(0.0);
+    (*value)[7] = p_LoCp_z() - T(0.0);
+    (*value)[8] = gravity() - T(0.0);
+  }
+};
+
+}  // namespace delphyne

--- a/src/gen/dynamic_bicycle_car_state.cc
+++ b/src/gen/dynamic_bicycle_car_state.cc
@@ -1,0 +1,32 @@
+// Copyright 2018 Toyota Research Institute
+
+#include "gen/dynamic_bicycle_car_state.h"
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+namespace delphyne {
+
+const int DynamicBicycleCarStateIndices::kNumCoordinates;
+const int DynamicBicycleCarStateIndices::kPLocpX;
+const int DynamicBicycleCarStateIndices::kPLocpY;
+const int DynamicBicycleCarStateIndices::kYawLc;
+const int DynamicBicycleCarStateIndices::kVLcpX;
+const int DynamicBicycleCarStateIndices::kVLcpY;
+const int DynamicBicycleCarStateIndices::kYawdtLc;
+
+const std::vector<std::string>&
+DynamicBicycleCarStateIndices::GetCoordinateNames() {
+  static const drake::never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "p_LoCp_x",  // BR
+          "p_LoCp_y",  // BR
+          "yaw_LC",    // BR
+          "v_LCp_x",   // BR
+          "v_LCp_y",   // BR
+          "yawDt_LC",  // BR
+      });
+  return coordinates.access();
+}
+
+}  // namespace delphyne

--- a/src/gen/dynamic_bicycle_car_state.h
+++ b/src/gen/dynamic_bicycle_car_state.h
@@ -1,0 +1,139 @@
+// Copyright 2018 Toyota Research Institute
+
+#pragma once
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+
+#include <drake/common/drake_bool.h>
+#include <drake/common/dummy_value.h>
+#include <drake/common/never_destroyed.h>
+#include <drake/common/symbolic.h>
+#include <drake/systems/framework/basic_vector.h>
+
+namespace delphyne {
+
+/// Describes the row indices of a DynamicBicycleCarState.
+struct DynamicBicycleCarStateIndices {
+  /// The total number of rows (coordinates).
+  static const int kNumCoordinates = 6;
+
+  // The index of each individual coordinate.
+  static const int kPLocpX = 0;
+  static const int kPLocpY = 1;
+  static const int kYawLc = 2;
+  static const int kVLcpX = 3;
+  static const int kVLcpY = 4;
+  static const int kYawdtLc = 5;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `DynamicBicycleCarStateIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
+};
+
+/// Specializes BasicVector with specific getters and setters.
+template <typename T>
+class DynamicBicycleCarState final : public drake::systems::BasicVector<T> {
+ public:
+  /// An abbreviation for our row index constants.
+  typedef DynamicBicycleCarStateIndices K;
+
+  /// Default constructor.  Sets all rows to their default value:
+  /// @arg @c p_LoCp_x defaults to 0.0 m.
+  /// @arg @c p_LoCp_y defaults to 0.0 m.
+  /// @arg @c yaw_LC defaults to 0.0 rad.
+  /// @arg @c v_LCp_x defaults to 0.0 m/s.
+  /// @arg @c v_LCp_y defaults to 0.0 m/s.
+  /// @arg @c yawDt_LC defaults to 0.0 rad/s.
+  DynamicBicycleCarState()
+      : drake::systems::BasicVector<T>(K::kNumCoordinates) {
+    this->set_p_LoCp_x(0.0);
+    this->set_p_LoCp_y(0.0);
+    this->set_yaw_LC(0.0);
+    this->set_v_LCp_x(0.0);
+    this->set_v_LCp_y(0.0);
+    this->set_yawDt_LC(0.0);
+  }
+
+  /// Create a drake::symbolic::Variable for each element with the known
+  /// variable
+  /// name.  This is only available for T == drake::symbolic::Expression.
+  template <typename U = T>
+  typename std::enable_if<
+      std::is_same<U, drake::symbolic::Expression>::value>::type
+  SetToNamedVariables() {
+    this->set_p_LoCp_x(drake::symbolic::Variable("p_LoCp_x"));
+    this->set_p_LoCp_y(drake::symbolic::Variable("p_LoCp_y"));
+    this->set_yaw_LC(drake::symbolic::Variable("yaw_LC"));
+    this->set_v_LCp_x(drake::symbolic::Variable("v_LCp_x"));
+    this->set_v_LCp_y(drake::symbolic::Variable("v_LCp_y"));
+    this->set_yawDt_LC(drake::symbolic::Variable("yawDt_LC"));
+  }
+
+  DynamicBicycleCarState<T>* DoClone() const final {
+    return new DynamicBicycleCarState;
+  }
+
+  /// @name Getters and Setters
+  //@{
+  /// Lx measure of the location of Cp from Lo.
+  /// @note @c p_LoCp_x is expressed in units of m.
+  const T& p_LoCp_x() const { return this->GetAtIndex(K::kPLocpX); }
+  void set_p_LoCp_x(const T& p_LoCp_x) {
+    this->SetAtIndex(K::kPLocpX, p_LoCp_x);
+  }
+  /// Ly measure of the location of Cp from Lo.
+  /// @note @c p_LoCp_y is expressed in units of m.
+  const T& p_LoCp_y() const { return this->GetAtIndex(K::kPLocpY); }
+  void set_p_LoCp_y(const T& p_LoCp_y) {
+    this->SetAtIndex(K::kPLocpY, p_LoCp_y);
+  }
+  /// Yaw angle from Lx to Cx with positive Lz sense.
+  /// @note @c yaw_LC is expressed in units of rad.
+  const T& yaw_LC() const { return this->GetAtIndex(K::kYawLc); }
+  void set_yaw_LC(const T& yaw_LC) { this->SetAtIndex(K::kYawLc, yaw_LC); }
+  /// Cx measure of Cp's velocity in L.
+  /// @note @c v_LCp_x is expressed in units of m/s.
+  const T& v_LCp_x() const { return this->GetAtIndex(K::kVLcpX); }
+  void set_v_LCp_x(const T& v_LCp_x) { this->SetAtIndex(K::kVLcpX, v_LCp_x); }
+  /// Cy measure of Cp's velocity in L.
+  /// @note @c v_LCp_y is expressed in units of m/s.
+  const T& v_LCp_y() const { return this->GetAtIndex(K::kVLcpY); }
+  void set_v_LCp_y(const T& v_LCp_y) { this->SetAtIndex(K::kVLcpY, v_LCp_y); }
+  /// C's angular velocity in frame L.
+  /// @note @c yawDt_LC is expressed in units of rad/s.
+  const T& yawDt_LC() const { return this->GetAtIndex(K::kYawdtLc); }
+  void set_yawDt_LC(const T& yawDt_LC) {
+    this->SetAtIndex(K::kYawdtLc, yawDt_LC);
+  }
+  //@}
+
+  /// See DynamicBicycleCarStateIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return DynamicBicycleCarStateIndices::GetCoordinateNames();
+  }
+
+  /// Returns whether the current values of this vector are well-formed.
+  drake::scalar_predicate_t<T> IsValid() const {
+    using std::isnan;
+    drake::scalar_predicate_t<T> result{true};
+    result = result && !isnan(p_LoCp_x());
+    result = result && !isnan(p_LoCp_y());
+    result = result && !isnan(yaw_LC());
+    result = result && !isnan(v_LCp_x());
+    result = result && !isnan(v_LCp_y());
+    result = result && !isnan(yawDt_LC());
+    return result;
+  }
+};
+
+}  // namespace delphyne

--- a/src/systems/bicycle_car.cc
+++ b/src/systems/bicycle_car.cc
@@ -1,0 +1,179 @@
+// Copyright 2018 Toyota Research Institute
+//
+#include "systems/bicycle_car.h"
+
+#include <cmath>
+#include <memory>
+#include <utility>
+
+#include <Eigen/Geometry>
+
+#include <drake/common/default_scalars.h>
+#include <drake/common/drake_assert.h>
+
+namespace delphyne {
+
+template <typename T>
+BicycleCar<T>::BicycleCar()
+    : drake::systems::LeafSystem<T>(
+          drake::systems::SystemTypeTag<BicycleCar>{}) {
+  auto& steering_input =
+      this->DeclareInputPort(drake::systems::kVectorValued, 1);
+  auto& force_input = this->DeclareInputPort(drake::systems::kVectorValued, 1);
+  auto& state_output = this->DeclareVectorOutputPort(&BicycleCar::CopyOutState);
+  static_assert(BicycleCarStateIndices::kPsi == 0,
+                "BicycleCar requires BicycleCarStateIndices::kPsi to be the "
+                "0th element.");
+  static_assert(BicycleCarStateIndices::kPsiDot == 1,
+                "BicycleCar requires BicycleCarStateIndices::kPsiDot to be the "
+                "1st element.");
+  this->DeclareContinuousState(
+      BicycleCarState<T>(),
+      1,                                             // num_q (Ψ)
+      1,                                             // num_v (Ψ_dot)
+      BicycleCarStateIndices::kNumCoordinates - 2);  // num_z (all but Ψ, Ψ_dot)
+  // TODO(jadecastro): Expose translational second-order structure of `sx`, `sy`
+  // using `vel` as the generalized velocity (#5323).
+
+  steering_input_port_ = steering_input.get_index();
+  force_input_port_ = force_input.get_index();
+  state_output_port_ = state_output.get_index();
+
+  this->DeclareNumericParameter(BicycleCarParameters<T>());
+}
+
+template <typename T>
+template <typename U>
+BicycleCar<T>::BicycleCar(const BicycleCar<U>&) : BicycleCar() {}
+
+template <typename T>
+BicycleCar<T>::~BicycleCar() {}
+
+template <typename T>
+const drake::systems::InputPort<T>& BicycleCar<T>::get_steering_input_port()
+    const {
+  return drake::systems::System<T>::get_input_port(steering_input_port_);
+}
+
+template <typename T>
+const drake::systems::InputPort<T>& BicycleCar<T>::get_force_input_port()
+    const {
+  return drake::systems::System<T>::get_input_port(force_input_port_);
+}
+
+template <typename T>
+const drake::systems::OutputPort<T>& BicycleCar<T>::get_state_output_port()
+    const {
+  return drake::systems::System<T>::get_output_port(state_output_port_);
+}
+
+template <typename T>
+void BicycleCar<T>::CopyOutState(const drake::systems::Context<T>& context,
+                                 BicycleCarState<T>* output_vector) const {
+  // Obtain the state.
+  const drake::systems::VectorBase<T>& context_state =
+      context.get_continuous_state_vector();
+  const BicycleCarState<T>* const state =
+      dynamic_cast<const BicycleCarState<T>*>(&context_state);
+  DRAKE_ASSERT(state != nullptr);
+
+  output_vector->set_value(state->get_value());
+}
+
+// Calculate the continuous-time derivatives.
+template <typename T>
+void BicycleCar<T>::DoCalcTimeDerivatives(
+    const drake::systems::Context<T>& context,
+    drake::systems::ContinuousState<T>* derivatives) const {
+  // Obtain the parameters, states, inputs, and state derivatives.
+  const int kParamsIndex = 0;
+  const BicycleCarParameters<T>& params =
+      this->template GetNumericParameter<BicycleCarParameters>(context,
+                                                               kParamsIndex);
+  const drake::systems::VectorBase<T>& context_state =
+      context.get_continuous_state_vector();
+  const BicycleCarState<T>* const state =
+      dynamic_cast<const BicycleCarState<T>*>(&context_state);
+  DRAKE_ASSERT(state != nullptr);
+
+  const drake::systems::BasicVector<T>* steering =
+      this->EvalVectorInput(context, get_steering_input_port().get_index());
+  DRAKE_ASSERT(steering != nullptr);
+
+  const drake::systems::BasicVector<T>* force =
+      this->EvalVectorInput(context, get_force_input_port().get_index());
+  DRAKE_ASSERT(force != nullptr);
+
+  DRAKE_ASSERT(derivatives != nullptr);
+  drake::systems::VectorBase<T>& derivative_vector =
+      derivatives->get_mutable_vector();
+  BicycleCarState<T>* const state_derivatives =
+      dynamic_cast<BicycleCarState<T>*>(&derivative_vector);
+  DRAKE_ASSERT(state_derivatives != nullptr);
+
+  ImplCalcTimeDerivatives(params, *state, *steering, *force, state_derivatives);
+}
+
+template <typename T>
+void BicycleCar<T>::ImplCalcTimeDerivatives(
+    const BicycleCarParameters<T>& params, const BicycleCarState<T>& state,
+    const drake::systems::BasicVector<T>& steering,
+    const drake::systems::BasicVector<T>& force,
+    BicycleCarState<T>* derivatives) const {
+  DRAKE_DEMAND(params.IsValid());
+
+  using std::pow;
+  using std::cos;
+  using std::sin;
+
+  // Parse and validate the parameters.
+  const T m = params.mass();
+  const T lr = params.lr();
+  const T lf = params.lf();
+  const T Iz = params.Iz();
+  const T Cf = params.Cf();
+  const T Cr = params.Cr();
+
+  DRAKE_DEMAND(m > 0.);
+  DRAKE_DEMAND(Iz > 0.);
+
+  // Parse the inputs.
+  const T delta = steering[0];
+  const T F_in = force[0];
+
+  // Parse and validate the states.
+  const T Psi{state.Psi()};
+  const T Psi_dot{state.Psi_dot()};
+  const T beta{state.beta()};
+  const T vel{state.vel()};
+
+  DRAKE_DEMAND(vel != 0.);  // N.B. Protection against the singular solution.
+  // TODO(jadecastro): Enable vel = 0. (see #5318).
+
+  const T torsional_stiffness = Cr * lr - Cf * lf;
+  const T front_torsional_stiffness = Cf * lf;
+  const T torsional_damping = (Cf * pow(lf, 2.) + Cr * pow(lr, 2.)) / vel;
+
+  // Compute the differential equations of motion.
+  const T Psi_ddot = torsional_stiffness / Iz * beta -
+                     torsional_damping / Iz * Psi_dot +
+                     front_torsional_stiffness / Iz * delta;
+  const T beta_dot = (torsional_stiffness / (m * pow(vel, 2.)) - 1.) * Psi_dot +
+                     Cf / (m * vel) * delta - (Cf + Cr) / (m * vel) * beta;
+  const T vel_dot = F_in / m;  // a_x in Althoff & Dolan, 2014.
+  const T sx_dot = vel * cos(beta + Psi);
+  const T sy_dot = vel * sin(beta + Psi);
+
+  derivatives->set_Psi(Psi_dot);
+  derivatives->set_Psi_dot(Psi_ddot);
+  derivatives->set_beta(beta_dot);
+  derivatives->set_vel(vel_dot);
+  derivatives->set_sx(sx_dot);
+  derivatives->set_sy(sy_dot);
+}
+
+}  // namespace delphyne
+
+// These instantiations must match the API documentation in bicycle_car.h.
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::delphyne::BicycleCar)

--- a/src/systems/bicycle_car.h
+++ b/src/systems/bicycle_car.h
@@ -1,0 +1,108 @@
+// Copyright 2018 Toyota Research Institute
+
+#pragma once
+
+#include <memory>
+
+#include <Eigen/Geometry>
+
+#include <drake/common/drake_copyable.h>
+#include <drake/systems/framework/leaf_system.h>
+
+#include "gen/bicycle_car_parameters.h"
+#include "gen/bicycle_car_state.h"
+
+namespace delphyne {
+
+/// BicycleCar implements a nonlinear rigid body bicycle model from Althoff &
+/// Dolan (2014) [1].  The three-DOF model captures the rigid-body dynamics in
+/// the lateral, longitudinal, and yaw directions but not in the roll and pitch
+/// directions.  The model assumes a vehicle that has two wheels: one at the
+/// front and one at the rear.  It has been demonstrated (e.g. [2]) that the
+/// representation reasonably approximates the dynamics of a four-wheeled
+/// vehicle; hence the model is useful as a simplified abstraction of car
+/// dynamics.
+///
+/// The states of the model are:
+///  - yaw angle Ψ [rad]
+///  - yaw rate Ψ_dot [rad/s]
+///  - slip angle at the center of mass β [rad]
+///  - velocity magnitude (vector magnitude at the slip angle) vel [m/s]
+///  - x-position of the center of mass sx [m]
+///  - y-position of the center of mass sy [m]
+///
+/// N.B. "slip angle" (β) is the angle made between the body and the velocity
+/// vector.  Thus, the velocity vector can be resolved into the body-relative
+/// components `vx_body = cos(β)` and `vy_body = sin(β)`.  `β = 0` means the
+/// velocity vector is pointing along the bicycle's longitudinal axis.
+///
+/// Inputs:
+///  - Angle of the front wheel of the bicycle δ [rad]
+///    (InputPort getter: get_steering_input_port())
+///  - Force acting on the rigid body F_in [N]
+///    (InputPort getter: get_force_input_port())
+///
+/// Output:
+///  - A BicycleCarState containing the 6-dimensional state vector of the
+///    bicycle.
+///    (OutputPort getter: get_state_output_port())
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+/// - drake::AutoDiffXd
+/// - drake::symbolic::Expression
+///
+/// They are already available to link against in libdrakeAutomotive.
+///
+/// [1] M. Althoff and J.M. Dolan, Online verification of automated road
+///     vehicles using reachability analysis, IEEE Transactions on Robotics,
+///     30(4), 2014, pp. 903-908.  DOI: 10.1109/TRO.2014.2312453.
+///
+/// [2] M. Althoff and J. M. Dolan, Reachability computation of low-order
+///     models for the safety verification of high-order road vehicle models,
+///     in Proc. of the American Control Conference, 2012, pp. 3559–3566.
+///
+/// @ingroup automotive_plants
+template <typename T>
+class BicycleCar final : public drake::systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BicycleCar)
+
+  /// Default constructor.
+  BicycleCar();
+
+  /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
+  template <typename U>
+  explicit BicycleCar(const BicycleCar<U>&);
+
+  ~BicycleCar() override;
+
+  /// Returns the input port that contains the steering angle.
+  const drake::systems::InputPort<T>& get_steering_input_port() const;
+
+  /// Returns the input port that contains the applied powertrain force.
+  const drake::systems::InputPort<T>& get_force_input_port() const;
+
+  /// Returns the output port that contains the bicycle states.
+  const drake::systems::OutputPort<T>& get_state_output_port() const;
+
+ private:
+  void CopyOutState(const drake::systems::Context<T>& context,
+                    BicycleCarState<T>* output) const;
+
+  void DoCalcTimeDerivatives(
+      const drake::systems::Context<T>& context,
+      drake::systems::ContinuousState<T>* derivatives) const override;
+
+  void ImplCalcTimeDerivatives(const BicycleCarParameters<T>& params,
+                               const BicycleCarState<T>& state,
+                               const drake::systems::BasicVector<T>& steering,
+                               const drake::systems::BasicVector<T>& force,
+                               BicycleCarState<T>* derivatives) const;
+
+  int steering_input_port_{};
+  int force_input_port_{};
+  int state_output_port_{};
+};
+
+}  // namespace delphyne

--- a/src/systems/create_trajectory_params.cc
+++ b/src/systems/create_trajectory_params.cc
@@ -1,0 +1,98 @@
+// Copyright 2018 Toyota Research Institute
+
+#include "systems/create_trajectory_params.h"
+
+#include <algorithm>
+#include <vector>
+
+#include "drake/automotive/maliput/api/junction.h"
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/automotive/maliput/api/segment.h"
+
+namespace delphyne {
+
+namespace {
+// A figure-eight.  One loop has a radius of @p radius - @p inset,
+// the other loop has a radius of @p radius + @p inset.
+Curve2<double> MakeCurve(double radius, double inset) {
+  // TODO(jwnimmer-tri) This function will be rewritten once we have
+  // proper splines.  Don't try too hard to understand it.  Run the
+  // demo to see it first, and only then try to understand the code.
+
+  typedef Curve2<double>::Point2 Point2d;
+  std::vector<Point2d> waypoints;
+
+  // Start (0, +i).
+  // Straight right to (+r, +i).
+  // Loop around (+i, +r).
+  // Straight back to (+i, 0).
+  waypoints.push_back({0.0, inset});
+  for (int theta_deg = -90; theta_deg <= 180; ++theta_deg) {
+    const Point2d center{radius, radius};
+    const double theta = theta_deg * M_PI / 180.0;
+    const Point2d direction{std::cos(theta), std::sin(theta)};
+    waypoints.push_back(center + (direction * (radius - inset)));
+  }
+  waypoints.push_back({inset, 0.0});
+
+  // Start (+i, 0).
+  // Straight down to (+i, -r).
+  // Loop around (-r, +i).
+  // Straight back to start (implicitly via segment to waypoints[0]).
+  for (int theta_deg = 0; theta_deg >= -270; --theta_deg) {
+    const Point2d center{-radius, -radius};
+    const double theta = theta_deg * M_PI / 180.0;
+    const Point2d direction{std::cos(theta), std::sin(theta)};
+    waypoints.push_back(center + (direction * (radius + inset)));
+  }
+
+  // Many copies.
+  const int kNumCopies = 100;
+  std::vector<Point2d> looped_waypoints;
+  for (int copies = 0; copies < kNumCopies; ++copies) {
+    std::copy(waypoints.begin(), waypoints.end(),
+              std::back_inserter(looped_waypoints));
+  }
+  looped_waypoints.push_back(waypoints.front());
+
+  return Curve2<double>(looped_waypoints);
+}
+}  // anonymous namespace
+
+std::tuple<Curve2<double>, double, double> CreateTrajectoryParams(int index) {
+  // The possible curves to trace (lanes).
+  static const std::vector<Curve2<double>> curves{
+      MakeCurve(40.0, 0.0),  // BR
+      MakeCurve(40.0, 4.0),  // BR
+      MakeCurve(40.0, 8.0),
+  };
+
+  // Magic car placement to make a good visual demo.
+  const auto& curve = curves[index % curves.size()];
+  const double start_time = (index / curves.size()) * 0.8;
+  const double kSpeed = 8.0;
+  return std::make_tuple(curve, kSpeed, start_time);
+}
+
+std::tuple<Curve2<double>, double, double> CreateTrajectoryParamsForDragway(
+    const drake::maliput::dragway::RoadGeometry& road_geometry, int index,
+    double speed, double start_time) {
+  const drake::maliput::api::Segment* segment =
+      road_geometry.junction(0)->segment(0);
+  DRAKE_DEMAND(index < segment->num_lanes());
+  const drake::maliput::api::Lane* lane = segment->lane(index);
+  const drake::maliput::api::GeoPosition start_geo_position =
+      lane->ToGeoPosition(
+          drake::maliput::api::LanePosition(0 /* s */, 0 /* r */, 0 /* h */));
+  const drake::maliput::api::GeoPosition end_geo_position =
+      lane->ToGeoPosition(drake::maliput::api::LanePosition(
+          lane->length() /* s */, 0 /* r */, 0 /* h */));
+  std::vector<Curve2<double>::Point2> waypoints;
+  waypoints.push_back({start_geo_position.x(), start_geo_position.y()});
+  waypoints.push_back({end_geo_position.x(), end_geo_position.y()});
+  Curve2<double> curve(waypoints);
+  return std::make_tuple(curve, speed, start_time);
+}
+
+}  // namespace delphyne

--- a/src/systems/create_trajectory_params.h
+++ b/src/systems/create_trajectory_params.h
@@ -1,0 +1,46 @@
+// Copyright 2018 Toyota Research Institute
+
+#pragma once
+
+// TODO(jwnimmer-tri) This file provides trajectories in support of demos.
+// This data should come from files loaded at runtime, instead.
+
+#include <memory>
+#include <tuple>
+
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/dragway/road_geometry.h"
+
+#include "systems/curve2.h"
+
+namespace delphyne {
+
+/**
+ * Creates TrajectoryCar constructor demo arguments.  The details of the
+ * trajectory are not documented / promised by this API.
+ *
+ * @param index Selects which pre-programmed trajectory to use.
+ *
+ * @return tuple of curve, speed, start_time
+ */
+std::tuple<Curve2<double>, double, double> CreateTrajectoryParams(int index);
+
+/**
+ * Creates TrajectoryCar constructor demo arguments for a vehicle on a dragway.
+ * The details of the trajectory are not documented / promised by this API.
+ *
+ * @param road_geometry The dragway upon which the TrajectoryCar will travel.
+ *
+ * @param index The lane index within the provided `road_geometry`.
+ *
+ * @param speed The speed of the vehicle.
+ *
+ * @param start_time The time when the vehicle should start driving.
+ *
+ * @return tuple of curve, speed, start_time
+ */
+std::tuple<Curve2<double>, double, double> CreateTrajectoryParamsForDragway(
+    const drake::maliput::dragway::RoadGeometry& road_geometry, int index,
+    double speed, double start_time);
+
+}  // namespace delphyne

--- a/src/systems/driving_command_mux.cc
+++ b/src/systems/driving_command_mux.cc
@@ -1,0 +1,59 @@
+// Copyright 2018 Toyota Research Institute
+
+#include "systems/driving_command_mux.h"
+
+#include <numeric>
+#include <utility>
+
+#include <drake/common/default_scalars.h>
+
+namespace delphyne {
+
+template <typename T>
+DrivingCommandMux<T>::DrivingCommandMux()
+    : drake::systems::LeafSystem<T>(
+          drake::systems::SystemTypeTag<DrivingCommandMux>{}),
+      steering_port_index_(
+          this->DeclareInputPort(drake::systems::kVectorValued, 1).get_index()),
+      acceleration_port_index_(
+          this->DeclareInputPort(drake::systems::kVectorValued, 1)
+              .get_index()) {
+  this->DeclareVectorOutputPort(DrivingCommand<T>(),
+                                &DrivingCommandMux<T>::CombineInputsToOutput);
+}
+
+template <typename T>
+template <typename U>
+DrivingCommandMux<T>::DrivingCommandMux(const DrivingCommandMux<U>&)
+    : DrivingCommandMux<T>() {}
+
+template <typename T>
+const drake::systems::InputPort<T>& DrivingCommandMux<T>::steering_input()
+    const {
+  return drake::systems::System<T>::get_input_port(steering_port_index_);
+}
+
+template <typename T>
+const drake::systems::InputPort<T>& DrivingCommandMux<T>::acceleration_input()
+    const {
+  return drake::systems::System<T>::get_input_port(acceleration_port_index_);
+}
+
+template <typename T>
+void DrivingCommandMux<T>::CombineInputsToOutput(
+    const drake::systems::Context<T>& context,
+    DrivingCommand<T>* output) const {
+  const drake::systems::BasicVector<T>* steering =
+      this->EvalVectorInput(context, steering_port_index_);
+  DRAKE_DEMAND(steering->size() == 1);
+  output->set_steering_angle(steering->GetAtIndex(0));
+  const drake::systems::BasicVector<T>* acceleration =
+      this->EvalVectorInput(context, acceleration_port_index_);
+  DRAKE_DEMAND(acceleration->size() == 1);
+  output->set_acceleration(acceleration->GetAtIndex(0));
+}
+
+}  // namespace delphyne
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::delphyne::DrivingCommandMux)

--- a/src/systems/driving_command_mux.h
+++ b/src/systems/driving_command_mux.h
@@ -1,0 +1,61 @@
+// Copyright 2018 Toyota Research Institute
+
+#pragma once
+
+#include <drake/common/drake_copyable.h>
+#include <drake/systems/framework/leaf_system.h>
+
+#include "gen/driving_command.h"
+
+namespace delphyne {
+
+/// A special-purpose multiplexer that packs two scalar inputs, steering angle
+/// (in units rad) and acceleration (in units m/s^2), into a vector-valued
+/// output of type DrivingCommand<T>, where the inputs feed directly through to
+/// the output.
+///
+/// This class differs from systems::Multiplexer<T> constructed with a
+/// DrivingCommand<T> model vector because a BasicVector (and notably any of its
+/// subclasses) stored as T=double cannot yet be converted to another type.  See
+/// #8921.
+///
+/// @tparam T The vector element type, which must be a valid Eigen scalar.
+///
+/// Instantiated templates for the following `T` values are provided:
+/// - double
+/// - AutoDiffXd
+/// - symbolic::Expression
+///
+/// They are already available to link against in the containing library.
+/// Currently, no other values for `T` are supported.
+///
+/// @ingroup automotive_systems
+template <typename T>
+class DrivingCommandMux : public drake::systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DrivingCommandMux)
+
+  /// Constructs a %DrivingCommandMux with two scalar-valued input ports, and
+  /// one output port containing a DrivingCommand<T>.
+  DrivingCommandMux();
+
+  /// Scalar-converting copy constructor. See @ref system_scalar_conversion.
+  template <typename U>
+  explicit DrivingCommandMux(const DrivingCommandMux<U>&);
+
+  /// See the class description for details on the following input ports.
+  /// @{
+  const drake::systems::InputPort<T>& steering_input() const;
+  const drake::systems::InputPort<T>& acceleration_input() const;
+  /// @}
+
+ private:
+  // Packs a DrivingCommand based on the values seen at the input ports.
+  void CombineInputsToOutput(const drake::systems::Context<T>& context,
+                             DrivingCommand<T>* output) const;
+
+  const int steering_port_index_{};
+  const int acceleration_port_index_{};
+};
+
+}  // namespace delphyne

--- a/src/systems/dynamic_bicycle_car.cc
+++ b/src/systems/dynamic_bicycle_car.cc
@@ -1,0 +1,187 @@
+// Copyright 2018 Toyota Research Institute
+
+#include "systems/dynamic_bicycle_car.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include <drake/common/cond.h>
+#include <drake/common/default_scalars.h>
+
+namespace delphyne {
+
+template <typename T>
+DynamicBicycleCar<T>::DynamicBicycleCar()
+    : drake::systems::LeafSystem<T>(
+          drake::systems::SystemTypeTag<DynamicBicycleCar>{}) {
+  this->DeclareVectorInputPort(DynamicBicycleCarInput<T>());
+  this->DeclareVectorOutputPort(DynamicBicycleCarState<T>(),
+                                &DynamicBicycleCar::CopyStateOut);
+
+  // Declares that this system has a continuous state of size
+  // DynamicBicycleCarState.size() and in a vector cloned from
+  // DynamicBicycleCarState.
+  this->DeclareContinuousState(DynamicBicycleCarState<T>());
+
+  // Declares the system's numeric parameters from the named vector
+  // dynamic_bicycle_car_params.named_vector.
+  this->DeclareNumericParameter(DynamicBicycleCarParams<T>());
+}
+
+template <typename T>
+const drake::systems::OutputPort<T>& DynamicBicycleCar<T>::get_output_port()
+    const {
+  return drake::systems::System<T>::get_output_port(0);
+}
+
+template <typename T>
+const drake::systems::InputPort<T>& DynamicBicycleCar<T>::get_input_port()
+    const {
+  return drake::systems::System<T>::get_input_port(0);
+}
+
+template <typename T>
+const DynamicBicycleCarState<T>& DynamicBicycleCar<T>::get_state(
+    const drake::systems::Context<T>& context) const {
+  const drake::systems::ContinuousState<T>& cstate =
+      context.get_continuous_state();
+  // Casts the continuous state vector from a VectorBase to a
+  // DynamicBicycleCarState vector.
+  return dynamic_cast<const DynamicBicycleCarState<T>&>(cstate.get_vector());
+}
+
+template <typename T>
+DynamicBicycleCarState<T>& DynamicBicycleCar<T>::get_mutable_state(
+    drake::systems::Context<T>* context) const {
+  drake::systems::ContinuousState<T>* cstate =
+      &context->get_mutable_continuous_state();
+  return dynamic_cast<DynamicBicycleCarState<T>&>(cstate->get_mutable_vector());
+}
+
+template <typename T>
+void DynamicBicycleCar<T>::CopyStateOut(
+    const drake::systems::Context<T>& context,
+    DynamicBicycleCarState<T>* output) const {
+  output->SetFrom(get_state(context));
+}
+
+template <typename T>
+T DynamicBicycleCar<T>::CalcTireSlip(const DynamicBicycleCarState<T>& state,
+                                     const DynamicBicycleCarParams<T>& params,
+                                     const T& steer_angle, Tire tire_select) {
+  using std::atan2;
+
+  if (tire_select == Tire::kFrontTire) {
+    // Front tire slip angle.
+    return atan2(state.v_LCp_y() + params.Lf() * state.yawDt_LC(),
+                 state.v_LCp_x()) -
+           steer_angle;
+  } else {
+    // Rear tire slip angle.
+    return atan2(state.v_LCp_y() - params.Lb() * state.yawDt_LC(),
+                 state.v_LCp_x());
+  }
+}
+
+template <typename T>
+T DynamicBicycleCar<T>::CalcNormalTireForce(
+    const DynamicBicycleCarParams<T>& params, const T& f_Cp_x,
+    Tire tire_select) {
+  if (tire_select == Tire::kFrontTire) {
+    // Front tire normal force.
+    return (1 / (params.Lf() + params.Lb())) *
+           (params.mass() * params.Lb() * params.gravity() -
+            params.p_LoCp_z() * f_Cp_x);
+  } else {
+    // Rear tire normal force.
+    return (1 / (params.Lf() + params.Lb())) *
+           (params.mass() * params.Lf() * params.gravity() +
+            params.p_LoCp_z() * f_Cp_x);
+  }
+}
+
+template <typename T>
+T DynamicBicycleCar<T>::CalcLateralTireForce(const T& tire_slip_angle,
+                                             const T& c_alpha, const T& f_z,
+                                             const T& mu) {
+  // Based on Fiala non-linear brush tire model as presented by Pacejka [2].
+
+  DRAKE_ASSERT(c_alpha >= 0.0);
+  DRAKE_ASSERT(mu >= 0.0);
+  DRAKE_ASSERT(f_z >= 0.0);  // non-negative normal force acting on the tire.
+
+  using std::pow;
+  using std::tan;
+  using std::abs;
+  using std::atan2;
+
+  const T f_y_non_saturated_tire =
+      -c_alpha * tan(tire_slip_angle) +
+      ((c_alpha * c_alpha) / (3 * mu * f_z)) * abs(tan(tire_slip_angle)) *
+          tan(tire_slip_angle) -
+      (pow(c_alpha, 3) / (27 * (mu * mu) * (f_z * f_z))) *
+          pow(tan(tire_slip_angle), 3);
+  const T f_y_saturated_tire =
+      -mu * f_z * abs(tire_slip_angle) / tire_slip_angle;
+
+  // Note: the cond function is used as an if-else statement in order to make
+  // the conditional symbolic::Expression capable.
+  return drake::cond(abs(tire_slip_angle) < atan2(3 * mu * f_z, c_alpha),
+                     f_y_non_saturated_tire, f_y_saturated_tire);
+}
+
+template <typename T>
+void DynamicBicycleCar<T>::DoCalcTimeDerivatives(
+    const drake::systems::Context<T>& context,
+    drake::systems::ContinuousState<T>* derivatives) const {
+  using std::cos;
+  using std::max;
+
+  // Get the current state and derivative vectors of the system.
+  const DynamicBicycleCarState<T>& state = get_state(context);
+  DynamicBicycleCarState<T>& derivative_state =
+      dynamic_cast<DynamicBicycleCarState<T>&>(
+          derivatives->get_mutable_vector());
+
+  // Obtain the car parameters.
+  const DynamicBicycleCarParams<T>& params =
+      this->template GetNumericParameter<DynamicBicycleCarParams>(context, 0);
+
+  const T steer_CD = get_steer(context);
+  const T f_Cp_x = get_longitudinal_force(context);
+
+  // Calculate tire slip angles.
+  const T tire_slip_angle_f =
+      CalcTireSlip(state, params, steer_CD, Tire::kFrontTire);
+  const T tire_slip_angle_r =
+      CalcTireSlip(state, params, steer_CD, Tire::kRearTire);
+
+  // Calculate tire forces.
+  const T f_z_f = CalcNormalTireForce(params, f_Cp_x, Tire::kFrontTire);
+  const T f_z_r = CalcNormalTireForce(params, f_Cp_x, Tire::kRearTire);
+  const T f_y_f = CalcLateralTireForce(tire_slip_angle_f, params.c_alpha_f(),
+                                       f_z_f, params.mu());
+  const T f_y_r = CalcLateralTireForce(tire_slip_angle_r, params.c_alpha_r(),
+                                       f_z_r, params.mu());
+
+  // Catch to calculate sideslip angle when v_LoCp_x drops below 1 m/s.
+  const T sideslip = state.v_LCp_y() / max(1.0, state.v_LCp_x());
+
+  // Calculate state derivatives.
+  derivative_state.set_p_LoCp_x(state.v_LCp_x());
+  derivative_state.set_p_LoCp_y(state.v_LCp_y());
+  derivative_state.set_yaw_LC(state.yawDt_LC());
+  derivative_state.set_v_LCp_x((f_Cp_x / params.mass()) +
+                               state.yawDt_LC() * state.v_LCp_x() * sideslip);
+  derivative_state.set_v_LCp_y((f_y_f * cos(steer_CD) + f_y_r) / params.mass() -
+                               state.yawDt_LC() * state.v_LCp_x());
+  derivative_state.set_yawDt_LC(
+      (params.Lf() * f_y_f * cos(steer_CD) - params.Lb() * f_y_r) /
+      params.izz());
+}
+
+}  // namespace delphyne
+
+// Explicitly instantiate on default scalar types.
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::delphyne::DynamicBicycleCar)

--- a/src/systems/dynamic_bicycle_car.h
+++ b/src/systems/dynamic_bicycle_car.h
@@ -1,0 +1,140 @@
+// Copyright 2018 Toyota Research Institute
+
+#pragma once
+
+#include <drake/systems/framework/leaf_system.h>
+
+#include "gen/dynamic_bicycle_car_input.h"
+#include "gen/dynamic_bicycle_car_params.h"
+#include "gen/dynamic_bicycle_car_state.h"
+
+namespace delphyne {
+
+/// DynamicBicycleCar implements a planar rigid body bicycle model of an
+/// automobile with a non-linear brush tire model from Bobier (2012) [1]. This
+/// is a simplified model that assumes a vehicle that has two wheels: one at the
+/// front, and one at the rear. Also, this three-DOF model captures the dynamics
+/// in the lateral (Cy), longitudinal (Cx), and yaw (about Cz) directions but
+/// not the roll (about Cx) and pitch (about Cy) directions.
+///
+/// There are three coordinate frames of interest in this model: a local frame L
+/// fixed on earth with origin Lo, a frame attached to the vehicle's chassis C
+/// with the origin of C being Co located at a distance of Lf from the front
+/// axle along the center line of the vehicle, and a steering frame D with the
+/// origin Do located at the front axle along the center line of the vehicle.
+/// Note that the point Co is also referred to as the control point Cp, and
+/// although the location of the vehicle's center of mass Ccm can move depending
+/// on weight transfer dynamics, it is assumed that the location of Ccm is
+/// coincident with Co and Ccp. L is a cartesian, right handed coordinate system
+/// with Lz being gravity aligned (gravity acts in the negative Lz direction).
+///
+/// The states of the model are:
+///   - Lx measure of the location of Cp from Lo `p_LoCp_x` [m]
+///   - Ly measure of the location of Cp from Lo `p_LoCp_y` [m]
+///   - Yaw angle from Lx to Cx with positive Lz sense `yaw_LC` [rad]
+///   - Cx measure of Cp's velocity in L `v_LCp_x` [m/s]
+///   - Cy measure of Cp's velocity in L `v_LCp_y` [m/s]
+///   - C's angular velocity in frame L `yawDt_LC` [rad/s]
+///
+/// Inputs to this system:
+///   - Steer angle from Cx to Dx with positive Cz sense `steer_CD` [rad]
+///   - The Cx measure of the Longitudinal force on body C at Cp `f_Cp_x` [N]
+///
+/// Outputs of this system:
+///   - A DynamicBicycleCarState containing the 6-dimensional state vector of
+///     the vehicle.
+///
+/// Note that the vehicle's angular velocity in L `yawDt_LC` is sometimes
+/// referred to as the yaw rate `r`, and the tire angle is sometimes referred
+/// to as δ.
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+/// - drake::AutoDiffXd
+/// - drake::symbolic::Expression
+///
+/// [1] C. Bobier. A Phase Portrait Approach to Vehicle Stability
+///     and Envelope Control. Ph. D. thesis (Stanford University), 2012.
+///     pp. 22 - 25, pp. 35.
+///
+/// [2] H. Pacejka, Tire and vehicle dynamics, 3rd ed. Society of Automotive
+///     Engineers and Butterworth-Heinemann, 2012.
+///
+/// [3] G. Heydinger, R. Bixel, W. Garrott, M. Pyne, J. Howe and D. Guenther,
+///     "Measured Vehicle Inertial Parameters-NHTSA’s Data Through November
+///     1998", SAE Technical Paper Series, 1999. p. 24.
+///
+/// @ingroup automotive_plants
+
+template <typename T>
+class DynamicBicycleCar final : public drake::systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DynamicBicycleCar);
+
+  /// Default constructor.
+  DynamicBicycleCar();
+
+  /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
+  template <typename U>
+  explicit DynamicBicycleCar(const DynamicBicycleCar<U>&)
+      : DynamicBicycleCar<T>() {}
+
+  /// Specifies whether to use the front or rear tire for calculating various
+  /// parameters.
+  enum class Tire {
+    kFrontTire,
+    kRearTire,
+  };
+
+  /// Returns the port to output the state.
+  const drake::systems::OutputPort<T>& get_output_port() const;
+
+  /// Returns the input port to the tire angle and applied longitudinal force.
+  const drake::systems::InputPort<T>& get_input_port() const;
+
+  const DynamicBicycleCarState<T>& get_state(
+      const drake::systems::Context<T>& context) const;
+
+  DynamicBicycleCarState<T>& get_mutable_state(
+      drake::systems::Context<T>* context) const;
+
+  /// Slip angle of front or rear tires.
+  static T CalcTireSlip(const DynamicBicycleCarState<T>& state,
+                        const DynamicBicycleCarParams<T>& params,
+                        const T& steer_angle, Tire tire_select);
+
+  /// Normal forces on the front or rear tires.
+  static T CalcNormalTireForce(const DynamicBicycleCarParams<T>& params,
+                               const T& f_x, Tire tire_select);
+
+  /// Lateral tire forces on the front or rear tires.
+  static T CalcLateralTireForce(const T& tire_slip_angle, const T& c_alpha,
+                                const T& f_z, const T& mu);
+
+ private:
+  // Evaluates the input port and returns the scalar value of the steering
+  // angle.
+  const T get_steer(const drake::systems::Context<T>& context) const {
+    return this->EvalVectorInput(context, 0)
+        ->GetAtIndex(DynamicBicycleCarInputIndices::kSteerCd);
+  }
+
+  // Evaluates the input port and returns the scalar value of the longitudinal
+  // force.
+  const T get_longitudinal_force(
+      const drake::systems::Context<T>& context) const {
+    return this->EvalVectorInput(context, 0)
+        ->GetAtIndex(DynamicBicycleCarInputIndices::kFCpX);
+  }
+
+  // Copies the state out to the output port.
+  void CopyStateOut(const drake::systems::Context<T>& context,
+                    DynamicBicycleCarState<T>* output) const;
+
+  // Calculates the time derivatives of the state.
+  void DoCalcTimeDerivatives(
+      const drake::systems::Context<T>& context,
+      drake::systems::ContinuousState<T>* derivatives) const override;
+};
+
+}  // namespace delphyne

--- a/src/systems/road_path.cc
+++ b/src/systems/road_path.cc
@@ -1,0 +1,113 @@
+// Copyright 2018 Toyota Research Institute
+
+#include "systems/road_path.h"
+
+#include <vector>
+
+#include <drake/automotive/maliput/api/branch_point.h>
+#include <drake/automotive/maliput/api/lane.h>
+#include <drake/automotive/maliput/api/lane_data.h>
+#include <drake/common/cond.h>
+#include <drake/common/drake_assert.h>
+#include <drake/common/unused.h>
+#include <drake/math/saturate.h>
+
+namespace delphyne {
+
+using drake::maliput::api::GeoPosition;
+using drake::maliput::api::Lane;
+using drake::maliput::api::LaneEnd;
+using drake::maliput::api::LaneEndSet;
+using drake::maliput::api::RoadGeometry;
+using drake::trajectories::PiecewisePolynomial;
+using drake::MatrixX;
+using drake::Vector3;
+
+template <typename T>
+RoadPath<T>::RoadPath(const LaneDirection& initial_lane_direction,
+                      const T& step_size, int num_breaks)
+    : path_(MakePiecewisePolynomial(initial_lane_direction, step_size,
+                                    num_breaks)),
+      path_prime_(path_.derivative(1 /* 1st derivative */)),
+      path_double_prime_(path_.derivative(2 /* 2nd derivative */)) {}
+
+template <typename T>
+RoadPath<T>::~RoadPath() {}
+
+template <typename T>
+const PiecewisePolynomial<T>& RoadPath<T>::get_path() const {
+  return path_;
+}
+
+template <typename T>
+const T RoadPath<T>::GetClosestPathPosition(const Vector3<T>& geo_pos,
+                                            const T& s_guess) const {
+  drake::unused(geo_pos, s_guess);
+  DRAKE_ABORT();
+}
+
+template <typename T>
+const PiecewisePolynomial<T> RoadPath<T>::MakePiecewisePolynomial(
+    const LaneDirection& initial_lane_direction, const T& step_size,
+    int num_breaks) const {
+  std::vector<T> s_breaks{};
+  std::vector<MatrixX<T>> geo_knots(num_breaks, MatrixX<T>::Zero(3, 1));
+
+  LaneDirection ld = initial_lane_direction;
+  T s_lane{drake::cond(ld.with_s, T(0.), T(ld.lane->length()))};
+  T s_break{0.};
+
+  // Loop over all the breaks and extract the knot points.
+  for (int i = 0; i < num_breaks - 1; ++i) {
+    s_breaks.emplace_back(s_break);
+    s_break += T(step_size);
+
+    GeoPosition geo_pos =
+        ld.lane->ToGeoPosition({s_lane /* s */, 0. /* r */, 0. /* h */});
+    geo_knots[i] << T(geo_pos.x()), T(geo_pos.y()), T(geo_pos.z());
+
+    // Take a step.
+    if (ld.with_s) {
+      s_lane += T(step_size);
+    } else {
+      s_lane -= T(step_size);
+    }
+
+    // Compute the distance in excess of the lane boundary by taking this step.
+    const T out_distance{
+        drake::cond(ld.with_s, T(s_lane - ld.lane->length()), T(-s_lane))};
+    if (out_distance >= 0.) {
+      const LaneEndSet* lane_end_set{
+          ld.with_s ? ld.lane->GetOngoingBranches(LaneEnd::kFinish)
+                    : ld.lane->GetOngoingBranches(LaneEnd::kStart)};
+      if (lane_end_set->size() == 0) {  // There are no more ongoing lanes.
+        // If needed, add another knot point to make up the remaining distance.
+        if (out_distance != 0.) {
+          s_breaks.emplace_back(s_break + T(step_size - out_distance));
+          s_lane = drake::cond(ld.with_s, T(ld.lane->length()), T(0.));
+          geo_pos =
+              ld.lane->ToGeoPosition({s_lane /* s */, 0. /* r */, 0. /* h */});
+          geo_knots[i + 1] << T(geo_pos.x()), T(geo_pos.y()), T(geo_pos.z());
+        }
+        break;
+      }
+
+      // Always choose the first lane in the set as the new lane.
+      ld.lane = lane_end_set->get(0).lane;
+      ld.with_s = (lane_end_set->get(0).end == LaneEnd::kStart) ? true : false;
+
+      // Correct for the distance overshoot.
+      s_lane = drake::cond(ld.with_s, out_distance,
+                           T(ld.lane->length()) - out_distance);
+    }
+  }
+  // Resize the vector of knot points, if necessary.
+  geo_knots.resize(s_breaks.size());
+
+  // Create the resulting piecewise polynomial.
+  return PiecewisePolynomial<T>::Cubic(s_breaks, geo_knots);
+}
+
+template class RoadPath<double>;
+
+}  // namespace delphyne

--- a/src/systems/road_path.h
+++ b/src/systems/road_path.h
@@ -1,0 +1,77 @@
+// Copyright 2018 Toyota Research Institute
+
+#pragma once
+
+#include <drake/automotive/maliput/api/road_geometry.h>
+#include <drake/common/drake_copyable.h>
+#include <drake/common/eigen_types.h>
+#include <drake/common/trajectories/piecewise_polynomial.h>
+
+#include "systems/lane_direction.h"
+
+namespace delphyne {
+
+/// RoadPath converts a sequence of Maliput Lanes into a PiecewisePolynomial for
+/// the purpose of generating a path for a car to follow.  The path is created
+/// from the start of a user-specified initial lane and direction of travel, and
+/// proceeds in that direction until either the end of the road is reached
+/// (there exist no ongoing lanes), or the given number of specified breaks have
+/// been traversed.  The resulting path is a cubic spline that matches the `r =
+/// 0` coordinate of the lanes at each specified break point.  The resulting
+/// piecewise curve is C2-continuous throughout with zero first and second
+/// derivatives at the start and end of the path.
+///
+/// This class is explicitly instantiated for the following scalar types. No
+/// other scalar types are supported.
+/// - double
+///
+/// @tparam T The vector element type, which must be a valid Eigen scalar.
+///           Only double is supported.
+template <typename T>
+class RoadPath {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RoadPath)
+
+  /// Constructs a single RoadPath from a sequence of Maliput lanes based on the
+  /// following parameters:
+  /// @param initial_lane_direction contains the initial LaneDirection.  This
+  /// must be a valid @p road Lane.
+  /// @param step_size is the size of each step (in the `s`-direction) between
+  /// knot points.
+  /// @param num_breaks are the number of breaks at which the knot points will
+  /// be evaluated.
+  RoadPath(const LaneDirection& initial_lane_direction, const T& step_size,
+           int num_breaks);
+  ~RoadPath();
+
+  const drake::trajectories::PiecewisePolynomial<T>& get_path() const;
+
+  /// Computes the closest `s`-position on the path to an arbitrary point in
+  /// the world frame of the provided Maliput Lanes.  (Not yet implemented)
+  // TODO(jadecastro): Implement this.
+  const T GetClosestPathPosition(const drake::Vector3<T>& geo_position,
+                                 const T& s_guess) const;
+
+ private:
+  // Traverse the road, starting from an initial LaneDirection, and build a
+  // cubic spline PiecewisePolynomial until 1) a given a number of segments has
+  // been traversed, or 2) the end of the road has been reached.
+  //
+  // If a BranchPoint is encountered in which there is more than one ongoing
+  // lane, the zero-index lane is always selected.
+  // TODO(jadecastro): Use Lane::GetDefaultBranch() to decide the ongoing Lane.
+  const drake::trajectories::PiecewisePolynomial<T> MakePiecewisePolynomial(
+      const LaneDirection& initial_lane_direction, const T& step_size,
+      int num_breaks) const;
+
+  // The path representing the mid-curve of the road.
+  drake::trajectories::PiecewisePolynomial<T> path_;
+
+  // First derivative of path_.
+  drake::trajectories::PiecewisePolynomial<T> path_prime_;
+
+  // Second derivative of path_.
+  drake::trajectories::PiecewisePolynomial<T> path_double_prime_;
+};
+
+}  // namespace delphyne

--- a/src/systems/simple_powertrain.cc
+++ b/src/systems/simple_powertrain.cc
@@ -1,0 +1,10 @@
+// Copyright 2018 Toyota Research Institute
+
+#include "systems/simple_powertrain.h"
+
+#include <drake/common/default_scalars.h>
+
+// These instantiations must match the API documentation in
+// simple_powertrain.h.
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::delphyne::SimplePowertrain)

--- a/src/systems/simple_powertrain.h
+++ b/src/systems/simple_powertrain.h
@@ -1,0 +1,74 @@
+// Copyright 2018 Toyota Research Institute
+
+#pragma once
+
+#include <drake/systems/primitives/linear_system.h>
+
+namespace delphyne {
+
+/// SimplePowertrain models a powertrain with first-order lag. It accepts
+/// throttle as the input and outputs the applied lumped force from the vehicle
+/// to the road.
+///
+/// Input:
+///  - A unitless scalar value representing the throttle input to the power
+///    system.
+///
+/// Output:
+///  - The force transmitted from the vehicle to the road [N].
+///
+/// @tparam T The vector element type, which must be a valid Eigen scalar.
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+/// - AutoDiffXd
+/// - symbolic::Expression
+///
+/// They are already available to link against in the containing library.
+///
+/// @ingroup automotive_plants
+template <typename T>
+class SimplePowertrain final : public drake::systems::LinearSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SimplePowertrain);
+
+  /// Constructs a simple powertrain model, specified via a fixed time-constant
+  /// and scalar gain.  The inputs are as follows:
+  /// @param time_constant is the rise time of the first-order lag [s].
+  /// @param gain is the gain converting throttle input to force output [N].
+  SimplePowertrain(double time_constant, double gain)
+      : drake::systems::LinearSystem<T>(
+            drake::systems::SystemTypeTag<SimplePowertrain>{},
+            drake::Vector1d(-1. / time_constant), drake::Vector1d(gain),
+            drake::Vector1d(1. / time_constant), drake::Vector1d(0.),
+            0.0 /* time_period */),
+        time_constant_(time_constant),
+        gain_(gain) {}
+
+  /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
+  template <typename U>
+  explicit SimplePowertrain(const SimplePowertrain<U>& other)
+      : SimplePowertrain<T>(other.get_time_constant(), other.get_gain()) {}
+
+  ~SimplePowertrain() override = default;
+
+  const drake::systems::InputPort<T>& get_throttle_input_port() const {
+    return drake::systems::System<T>::get_input_port(0);
+  }
+
+  const drake::systems::OutputPort<T>& get_force_output_port() const {
+    return drake::systems::System<T>::get_output_port(0);
+  }
+
+  /// Accessors for the system constants.
+  /// @{
+  double get_time_constant() const { return time_constant_; }
+  double get_gain() const { return gain_; }
+  /// @}
+
+ private:
+  const double time_constant_{};
+  const double gain_{};
+};
+
+}  // namespace delphyne

--- a/test/regression/cpp/CMakeLists.txt
+++ b/test/regression/cpp/CMakeLists.txt
@@ -36,6 +36,8 @@ target_link_libraries(test_utilities
 set(SOURCES
   agent_diagram_builder_test.cc
   automotive_simulator_test.cc
+  bicycle_car_test.cc  
+  box_car_vis_test.cc
   calc_ongoing_road_position_test.cc
   calc_smooth_acceleration_test.cc
   car_vis_applicator_test.cc  
@@ -43,6 +45,8 @@ set(SOURCES
   compression_test.cc
   data_logger_test.cc
   drake_driving_command_to_ign_translator_system_test.cc
+  driving_command_mux_test.cc
+  dynamic_bicycle_car_test.cc  
   filesystem_test.cc
   frame_pose_aggregator_test.cc
   idm_controller_test.cc
@@ -62,7 +66,9 @@ set(SOURCES
   pure_pursuit_controller_test.cc
   pure_pursuit_test.cc
   resources_test.cc
+  road_path_test.cc
   simple_car_test.cc
+  simple_powertrain_test.cc
   scene_system_test.cc
   simulation_run_stats_test.cc
   simulation_runner_test.cc

--- a/test/regression/cpp/bicycle_car_test.cc
+++ b/test/regression/cpp/bicycle_car_test.cc
@@ -1,0 +1,227 @@
+// Copyright 2018 Toyota Research Institute
+
+#include "systems/bicycle_car.h"
+
+#include <cmath>
+#include <memory>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "test_utilities/eigen_matrix_compare.h"
+#include "test_utilities/scalar_conversion.h"
+
+namespace delphyne {
+
+using drake::Vector6;
+
+namespace {
+
+static constexpr int kStateDimension{BicycleCarStateIndices::kNumCoordinates};
+static constexpr int kSteeringInputDimension{1};
+static constexpr int kForceInputDimension{1};
+
+class BicycleCarTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    dut_.reset(new BicycleCar<double>());
+
+    context_ = dut_->CreateDefaultContext();
+    output_ = dut_->AllocateOutput();
+    derivatives_ = dut_->AllocateTimeDerivatives();
+  }
+
+  BicycleCarState<double>* continuous_state() {
+    auto& xc = context_->get_mutable_continuous_state_vector();
+    BicycleCarState<double>* state =
+        dynamic_cast<BicycleCarState<double>*>(&xc);
+    DRAKE_DEMAND(state != nullptr);
+    return state;
+  }
+
+  const BicycleCarState<double>* derivatives() const {
+    const auto derivatives = dynamic_cast<const BicycleCarState<double>*>(
+        &derivatives_->get_mutable_vector());
+    DRAKE_DEMAND(derivatives != nullptr);
+    return derivatives;
+  }
+
+  void SetInputs(const double steering_angle, const double force) {
+    ASSERT_NE(nullptr, dut_);
+    ASSERT_NE(nullptr, context_);
+
+    std::unique_ptr<drake::systems::BasicVector<double>> steering_input(
+        new drake::systems::BasicVector<double>(kSteeringInputDimension));
+    std::unique_ptr<drake::systems::BasicVector<double>> force_input(
+        new drake::systems::BasicVector<double>(kForceInputDimension));
+
+    (*steering_input)[0] = steering_angle;
+    (*force_input)[0] = force;
+
+    const int kSteeringIndex = dut_->get_steering_input_port().get_index();
+    const int kForceIndex = dut_->get_force_input_port().get_index();
+    context_->FixInputPort(kSteeringIndex, std::move(steering_input));
+    context_->FixInputPort(kForceIndex, std::move(force_input));
+  }
+
+  std::unique_ptr<BicycleCar<double>> dut_;  //< The device under test.
+  std::unique_ptr<drake::systems::Context<double>> context_;
+  std::unique_ptr<drake::systems::SystemOutput<double>> output_;
+  std::unique_ptr<drake::systems::ContinuousState<double>> derivatives_;
+};
+
+TEST_F(BicycleCarTest, Topology) {
+  ASSERT_EQ(2, dut_->get_num_input_ports()); /* steering angle, force input */
+
+  const auto& steering_input_port = dut_->get_steering_input_port();
+  EXPECT_EQ(drake::systems::kVectorValued, steering_input_port.get_data_type());
+  EXPECT_EQ(kSteeringInputDimension, steering_input_port.size());
+
+  const auto& force_input_port = dut_->get_force_input_port();
+  EXPECT_EQ(drake::systems::kVectorValued, force_input_port.get_data_type());
+  EXPECT_EQ(kForceInputDimension, force_input_port.size());
+
+  ASSERT_EQ(1, dut_->get_num_output_ports()); /* state vector */
+
+  const auto& state_port = dut_->get_output_port(0);
+  EXPECT_EQ(drake::systems::kVectorValued, state_port.get_data_type());
+  EXPECT_EQ(kStateDimension, state_port.size());
+}
+
+TEST_F(BicycleCarTest, ToAutoDiff) {
+  EXPECT_TRUE(is_autodiffxd_convertible(*dut_));
+}
+
+TEST_F(BicycleCarTest, ToSymbolic) {
+  EXPECT_TRUE(is_symbolic_convertible(*dut_));
+}
+
+TEST_F(BicycleCarTest, DirectFeedthrough) {
+  EXPECT_FALSE(dut_->HasAnyDirectFeedthrough());
+}
+
+TEST_F(BicycleCarTest, Output) {
+  const double kTolerance = 1e-10;
+
+  // Set the steering angle and the applied force to positive values.
+  SetInputs(1., 10.);
+
+  auto output = output_->get_vector_data(0);
+
+  // Set all the states to one.
+  continuous_state()->SetFromVector(Vector6<double>::Ones());
+
+  dut_->CalcOutput(*context_, output_.get());
+  const Vector6<double> result = output->CopyToVector();
+
+  // Expect that the output matches the states, since there is no feedthrough.
+  EXPECT_TRUE(test::CompareMatrices(result, Vector6<double>::Ones(), kTolerance,
+                                    test::MatrixCompareType::absolute));
+}
+
+// Tests the consistency of the derivatives when a trivial set of states is
+// provided, with no steering and some positive input force.
+TEST_F(BicycleCarTest, TrivialDerivatives) {
+  const double kForceInput = 10.;
+  const double kVelocityState = 1.;
+
+  // Keep the steering angle zero and set the force to a positive value.
+  SetInputs(0., kForceInput);
+
+  // Set all the states to zero except velocity, which must be kept positive.
+  continuous_state()->SetFromVector(Vector6<double>::Zero());
+  continuous_state()->set_vel(kVelocityState);
+
+  dut_->CalcTimeDerivatives(*context_, derivatives_.get());
+
+  // We expect all derivatives to be zero except vel_dot and sx_dot, since
+  // applying a positive force input and zero steering angle translates into
+  // along-track motion.
+  EXPECT_EQ(0., derivatives()->Psi());
+  EXPECT_EQ(0., derivatives()->Psi_dot());
+  EXPECT_EQ(0., derivatives()->beta());
+  EXPECT_LT(0., derivatives()->vel());
+  EXPECT_EQ(kVelocityState, derivatives()->sx());
+  EXPECT_EQ(0., derivatives()->sy());
+}
+
+// Tests that one equation has terms that cancel for some parameter-independent
+// settings, and that the remaining equations are still consistent, including
+// the kinematics equations.
+TEST_F(BicycleCarTest, DerivativesPositiveBetaPositiveDelta) {
+  const double kSteeringInput = 1.;  // An angle in the first quadrant.
+  const double kForceInput = 10.;
+  const double kVelocityState = 1.;
+
+  // Set the steering angle and force to positive values.
+  SetInputs(kSteeringInput, kForceInput);
+
+  // Set β to δ / 2 and the velocity to a positive value.
+  continuous_state()->SetFromVector(Vector6<double>::Zero());
+  continuous_state()->set_beta(kSteeringInput / 2.);
+  continuous_state()->set_vel(kVelocityState);
+
+  dut_->CalcTimeDerivatives(*context_, derivatives_.get());
+
+  // We expect the first and third terms in β_dot to cancel, and Ψ_ddot, vel_dot
+  // to be strictly positive. We expect sx_dot, and sy_dot to be
+  // strictly-positive as the steering angle is in the first quadrant.
+  EXPECT_LT(0., derivatives()->Psi_dot());
+  EXPECT_EQ(0., derivatives()->beta());
+  EXPECT_LT(0., derivatives()->vel());
+  EXPECT_LT(0., derivatives()->sx());
+  EXPECT_LT(0., derivatives()->sy());
+}
+
+// Tests the consistency of the derivatives and kinematic relationships upon
+// feeding in a negative slip angle, keeping the other parameters the same as
+// the previous case.
+TEST_F(BicycleCarTest, DerivativesNegativeBetaPositiveDelta) {
+  const double kSteeringInput = 1.;  // An angle in the fourth quadrant.
+  const double kForceInput = 10.;
+  const double kVelocityState = 1.;
+
+  // Set the steering angle and force to positive values.
+  SetInputs(kSteeringInput, kForceInput);
+
+  // Set β to -δ and the velocity to a positive value.
+  continuous_state()->SetFromVector(Vector6<double>::Zero());
+  continuous_state()->set_beta(-kSteeringInput);
+  continuous_state()->set_vel(kVelocityState);
+
+  dut_->CalcTimeDerivatives(*context_, derivatives_.get());
+
+  // We expect β_dot and vel_dot to return strictly-positive values. sx_dot and
+  // sy_dot, respectively, return positive and negative values, as the steering
+  // angle is in the fourth quadrant.  Note that Ψ_ddot is indeterminate.
+  EXPECT_LT(0., derivatives()->beta());
+  EXPECT_LT(0., derivatives()->vel());
+  EXPECT_LT(0., derivatives()->sx());
+  EXPECT_GT(0., derivatives()->sy());
+}
+
+// Tests the consistency of the derivatives and kinematic relationships upon
+// assigning a positive angular yaw rate.
+TEST_F(BicycleCarTest, DerivativesPositivePsiDot) {
+  const double kYawRateState = 2.;
+  const double kVelocityState = 1e3;  // Unrealistic velocity that reasonably
+                                      // enforces the condition that
+                                      // abs(Cr * lr - Cf * lf) < 1e6 * mass.
+
+  // Keep the steering angle and force zero.
+  SetInputs(0., 0.);
+
+  // Set Ψ_dot and the velocity to positive values.
+  continuous_state()->SetFromVector(Vector6<double>::Zero());
+  continuous_state()->set_Psi_dot(kYawRateState);
+  continuous_state()->set_vel(kVelocityState);
+
+  dut_->CalcTimeDerivatives(*context_, derivatives_.get());
+
+  // We expect both β_dot and Ψ_ddot to be strictly negative.
+  EXPECT_GT(0., derivatives()->Psi_dot());
+  EXPECT_GT(0., derivatives()->beta());
+}
+
+}  // namespace
+}  // namespace delphyne

--- a/test/regression/cpp/box_car_vis_test.cc
+++ b/test/regression/cpp/box_car_vis_test.cc
@@ -1,0 +1,64 @@
+#include "visualization/box_car_vis.h"
+
+#include <Eigen/Dense>
+#include <gtest/gtest.h>
+
+#include <drake/lcmt_viewer_link_data.hpp>
+#include <drake/systems/rendering/pose_bundle.h>
+#include <drake/systems/rendering/pose_vector.h>
+
+#include "test_utilities/eigen_matrix_compare.h"
+
+using std::vector;
+
+namespace delphyne {
+
+using drake::systems::rendering::PoseBundle;
+using drake::systems::rendering::PoseVector;
+
+namespace {
+
+GTEST_TEST(BoxCarVisTest, BasicTest) {
+  const int kModelInstanceId = 1600;
+  const std::string kName = "Alice";
+
+  // Instantiates the device under test (DUT).
+  BoxCarVis<double> dut(kModelInstanceId, kName);
+
+  const vector<drake::lcmt_viewer_link_data>& vis_elements =
+      dut.GetVisElements();
+  EXPECT_EQ(vis_elements.size(), 1u);
+
+  const drake::lcmt_viewer_link_data& link_data = vis_elements.at(0);
+  EXPECT_EQ(link_data.name, kName);
+  EXPECT_EQ(link_data.robot_num, kModelInstanceId);
+  EXPECT_EQ(link_data.num_geom, 1);
+
+  const drake::lcmt_viewer_geometry_data& geom_data = link_data.geom.at(0);
+  const int kExpectedGeomType = drake::lcmt_viewer_geometry_data::BOX;
+  EXPECT_EQ(geom_data.type, kExpectedGeomType);
+
+  PoseVector<double> root_pose;
+  root_pose.set_translation({1, 2, 3});
+  root_pose.set_rotation({0, 0, 0, -1});
+  const PoseBundle<double> vis_poses = dut.CalcPoses(root_pose.get_isometry());
+  EXPECT_EQ(vis_poses.get_num_poses(), 1);
+
+  Eigen::Isometry3d expected_pose = Eigen::Isometry3d::Identity();
+  {
+    expected_pose.translation().x() = 1;
+    expected_pose.translation().y() = 2;
+    expected_pose.translation().z() = 3;
+    expected_pose.rotate(Eigen::Quaterniond({0, 0, 0, -1}));
+  }
+  // The following tolerance was empirically determined.
+  EXPECT_TRUE(test::CompareMatrices(vis_poses.get_pose(0).matrix(),
+                                    expected_pose.matrix(),
+                                    1e-15 /* tolerance */));
+
+  EXPECT_EQ(vis_poses.get_model_instance_id(0), kModelInstanceId);
+  EXPECT_EQ(vis_poses.get_name(0), kName);
+}
+
+}  // namespace
+}  // namespace delphyne

--- a/test/regression/cpp/driving_command_mux_test.cc
+++ b/test/regression/cpp/driving_command_mux_test.cc
@@ -1,0 +1,101 @@
+#include "systems/driving_command_mux.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include <drake/common/autodiff.h>
+#include <drake/common/symbolic.h>
+#include <drake/systems/framework/basic_vector.h>
+
+#include "gen/driving_command.h"
+#include "test_utilities/scalar_conversion.h"
+
+namespace delphyne {
+
+using drake::AutoDiffXd;
+
+namespace {
+
+class DrivingCommandMuxTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    mux_ = std::make_unique<DrivingCommandMux<double>>();
+    context_ = mux_->CreateDefaultContext();
+    output_ = mux_->AllocateOutput();
+  }
+
+  std::unique_ptr<DrivingCommandMux<double>> mux_;
+  std::unique_ptr<drake::systems::Context<double>> context_;
+  std::unique_ptr<drake::systems::SystemOutput<double>> output_;
+};
+
+TEST_F(DrivingCommandMuxTest, Basic) {
+  // Confirm the shape.
+  ASSERT_EQ(2, mux_->get_num_input_ports());
+  ASSERT_EQ(1, mux_->steering_input().size());
+  ASSERT_EQ(1, mux_->acceleration_input().size());
+  ASSERT_EQ(1, mux_->get_num_output_ports());
+  ASSERT_EQ(2, mux_->get_output_port(0).size());
+
+  // Confirm the output is indeed a DrivingCommand.
+  const DrivingCommand<double>* driving_command_output =
+      dynamic_cast<const DrivingCommand<double>*>(output_->get_vector_data(0));
+  ASSERT_NE(nullptr, driving_command_output);
+
+  // Provide input data.
+  context_->FixInputPort(mux_->steering_input().get_index(),
+                         drake::systems::BasicVector<double>::Make({42.}));
+  context_->FixInputPort(mux_->acceleration_input().get_index(),
+                         drake::systems::BasicVector<double>::Make({11.}));
+
+  // Confirm output data.
+  mux_->CalcOutput(*context_, output_.get());
+  ASSERT_EQ(42., driving_command_output->steering_angle());
+  ASSERT_EQ(11., driving_command_output->acceleration());
+}
+
+TEST_F(DrivingCommandMuxTest, IsStateless) {
+  EXPECT_EQ(0, context_->get_continuous_state().size());
+}
+
+// Tests conversion to AutoDiffXd.
+TEST_F(DrivingCommandMuxTest, ToAutoDiff) {
+  EXPECT_TRUE(is_autodiffxd_convertible(*mux_, [&](const auto& converted) {
+    EXPECT_EQ(2, converted.get_num_input_ports());
+    EXPECT_EQ(1, converted.get_num_output_ports());
+
+    EXPECT_EQ(1, converted.get_input_port(0).size());
+    EXPECT_EQ(1, converted.get_input_port(1).size());
+    EXPECT_EQ(2, converted.get_output_port(0).size());
+
+    const auto context = converted.CreateDefaultContext();
+    const auto output = converted.AllocateOutput();
+    const DrivingCommand<AutoDiffXd>* driving_command_output =
+        dynamic_cast<const DrivingCommand<AutoDiffXd>*>(
+            output->get_vector_data(0));
+    EXPECT_NE(nullptr, driving_command_output);
+  }));
+}
+
+// Tests conversion to drake::symbolic::Expression.
+TEST_F(DrivingCommandMuxTest, ToSymbolic) {
+  EXPECT_TRUE(is_symbolic_convertible(*mux_, [&](const auto& converted) {
+    EXPECT_EQ(2, converted.get_num_input_ports());
+    EXPECT_EQ(1, converted.get_num_output_ports());
+
+    EXPECT_EQ(1, converted.get_input_port(0).size());
+    EXPECT_EQ(1, converted.get_input_port(1).size());
+    EXPECT_EQ(2, converted.get_output_port(0).size());
+
+    const auto context = converted.CreateDefaultContext();
+    const auto output = converted.AllocateOutput();
+    const DrivingCommand<drake::symbolic::Expression>* driving_command_output =
+        dynamic_cast<const DrivingCommand<drake::symbolic::Expression>*>(
+            output->get_vector_data(0));
+    EXPECT_NE(nullptr, driving_command_output);
+  }));
+}
+
+}  // namespace
+}  // namespace delphyne

--- a/test/regression/cpp/dynamic_bicycle_car_test.cc
+++ b/test/regression/cpp/dynamic_bicycle_car_test.cc
@@ -1,0 +1,384 @@
+#include "systems/dynamic_bicycle_car.h"
+
+#include <gtest/gtest.h>
+
+#include "test_utilities/scalar_conversion.h"
+
+namespace delphyne {
+
+using drake::Vector2;
+using drake::Vector6;
+
+namespace {
+
+// Struct to hold the test values for the different tests.
+struct TestValues {
+  // Initial state values.
+  double v_LCp_x = 0;
+  double yaw_LC = 0;
+
+  // Inputs initialized to zero.
+  double steer_angle = 0;
+  double f_Cp_x = 0;  // Longitudinal force
+
+  // The set of TestValues.expected_<parameter> values are calculated using the
+  // equations for normal load, tire slip angle, and lateral tire force based on
+  // the dynamic bicycle model from Bobier (2012).
+
+  // Expected values initialized to zero.
+  double expected_tire_slip_angle_front = 0;
+  double expected_tire_slip_angle_rear = 0;
+  double expected_normal_load_front = 0;
+  double expected_normal_load_rear = 0;
+  double expected_lateral_force_front = 0;
+  double expected_lateral_force_rear = 0;
+
+  // Expected derivative values initialized to zero.
+  double expected_v_LCp_x = 0;
+  double expected_v_LCp_y = 0;
+  double expected_yawDt_LC = 0;
+  double expected_vDt_LCp_x = 0;
+  double expected_vDt_LCp_y = 0;
+  double expected_yawDDt_LC = 0;
+
+  // Tolerance used for testing the expected values.
+  const double tolerance = 1e-5;
+};
+
+// Test values for going in a straight line with constant velocity.
+TestValues GetTestValuesStraightConstV() {
+  TestValues test_values;
+  DynamicBicycleCarParams<double> car_params;
+
+  // Set initial values for the state.
+  test_values.v_LCp_x = 10;
+  test_values.yaw_LC = 0;
+
+  // Test inputs for constant velocity with zero steer input.
+  test_values.steer_angle = 0;
+  test_values.f_Cp_x = 0;
+
+  // Expected values.
+  test_values.expected_tire_slip_angle_front = 0;
+  test_values.expected_tire_slip_angle_rear = 0;
+  test_values.expected_normal_load_front = 7868.7972;
+  test_values.expected_normal_load_rear = 10014.8328;
+  test_values.expected_lateral_force_front = 0;
+  test_values.expected_lateral_force_rear = 0;
+
+  // Expected derivative values.
+  test_values.expected_v_LCp_x = 10;
+  test_values.expected_v_LCp_y = 0;
+  test_values.expected_yawDt_LC = 0;
+  test_values.expected_vDt_LCp_x = test_values.f_Cp_x / car_params.mass();
+  test_values.expected_vDt_LCp_y = 0;
+  test_values.expected_yawDDt_LC = 0;
+
+  return test_values;
+}
+
+// Test values for going around a curve with a positive steer angle.
+TestValues GetParamsCurve() {
+  TestValues test_values;
+  DynamicBicycleCarParams<double> car_params;
+
+  // Set initial values for the state.
+  test_values.v_LCp_x = 10;
+  test_values.yaw_LC = M_PI / 12;
+
+  // Test inputs
+  test_values.steer_angle = M_PI / 6;
+  test_values.f_Cp_x = 0;
+
+  // Expected values.
+  test_values.expected_tire_slip_angle_front = -0.5236;
+  test_values.expected_tire_slip_angle_rear = 0;
+  test_values.expected_normal_load_front = 7868.7972;
+  test_values.expected_normal_load_rear = 10014.8328;
+  test_values.expected_lateral_force_front = 4327.83846;
+  test_values.expected_lateral_force_rear = 0;
+
+  // Expected derivative values.
+  test_values.expected_v_LCp_x = 10;
+  test_values.expected_v_LCp_y = 0;
+  test_values.expected_yawDt_LC = 0;
+  test_values.expected_vDt_LCp_x = test_values.f_Cp_x / car_params.mass();
+  test_values.expected_vDt_LCp_y = 2.05596;
+  test_values.expected_yawDDt_LC = 2.88597;
+
+  return test_values;
+}
+
+// Test values for going around a curve with a negative steer angle.
+TestValues GetParamsCurveNegative() {
+  TestValues test_values;
+  DynamicBicycleCarParams<double> car_params;
+
+  // Set initial values for the state.
+  test_values.v_LCp_x = 10;
+  test_values.yaw_LC = -M_PI / 12;
+
+  // Test inputs
+  test_values.steer_angle = -M_PI / 6;
+  test_values.f_Cp_x = 0;
+
+  // Expected values.
+  test_values.expected_tire_slip_angle_front = 0.5236;
+  test_values.expected_tire_slip_angle_rear = 0;
+  test_values.expected_normal_load_front = 7868.7972;
+  test_values.expected_normal_load_rear = 10014.8328;
+  test_values.expected_lateral_force_front = -4327.83846;
+  test_values.expected_lateral_force_rear = 0;
+
+  // Expected derivative values initialized to zero.
+  test_values.expected_v_LCp_x = 10;
+  test_values.expected_v_LCp_y = 0;
+  test_values.expected_yawDt_LC = 0;
+  test_values.expected_vDt_LCp_x = test_values.f_Cp_x / car_params.mass();
+  test_values.expected_vDt_LCp_y = -2.05596;
+  test_values.expected_yawDDt_LC = -2.88597;
+
+  return test_values;
+}
+
+// Test fixture to help test the DynamicBicycle model.
+class DynamicBicycleCarTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    test_car_ = std::make_unique<DynamicBicycleCar<double>>();
+    test_car_params_ = std::make_unique<DynamicBicycleCarParams<double>>();
+    context_ = test_car_->CreateDefaultContext();
+    output_ = test_car_->AllocateOutput();
+    derivatives_ = test_car_->AllocateTimeDerivatives();
+    system_output_ = test_car_->AllocateOutput();
+  }
+
+  // Returns a pointer to the state vector.
+  DynamicBicycleCarState<double>* continuous_state() {
+    DynamicBicycleCarState<double>& state =
+        test_car_->get_mutable_state(context_.get());
+    return &state;
+  }
+
+  // Returns a pointer to the state derivatives vector.
+  const DynamicBicycleCarState<double>* state_derivatives() const {
+    const auto state_derivatives =
+        dynamic_cast<const DynamicBicycleCarState<double>*>(
+            &derivatives_->get_mutable_vector());
+    return state_derivatives;
+  }
+
+  // Tests the slip angle of the front and rear tires based on the expected
+  // values contained in the input struct.
+  void TestTireSlipAngle(TestValues test_values) {
+    const double tire_slip_angle_front = test_car_->CalcTireSlip(
+        *continuous_state(), *test_car_params_, test_values.steer_angle,
+        DynamicBicycleCar<double>::Tire::kFrontTire);
+    const double tire_slip_angle_rear = test_car_->CalcTireSlip(
+        *continuous_state(), *test_car_params_, test_values.steer_angle,
+        DynamicBicycleCar<double>::Tire::kRearTire);
+
+    EXPECT_NEAR(tire_slip_angle_front,
+                test_values.expected_tire_slip_angle_front,
+                test_values.tolerance);
+    EXPECT_NEAR(tire_slip_angle_rear, test_values.expected_tire_slip_angle_rear,
+                test_values.tolerance);
+  }
+
+  // Tests the normal forces on the front and rear tires based on the expected
+  // values contained in the input struct.
+  void TestNormalLoad(TestValues test_values) {
+    const double normal_load_front = test_car_->CalcNormalTireForce(
+        *test_car_params_, test_values.f_Cp_x,
+        DynamicBicycleCar<double>::Tire::kFrontTire);
+    const double normal_load_rear = test_car_->CalcNormalTireForce(
+        *test_car_params_, test_values.f_Cp_x,
+        DynamicBicycleCar<double>::Tire::kRearTire);
+
+    EXPECT_NEAR(normal_load_front, test_values.expected_normal_load_front,
+                test_values.tolerance);
+    EXPECT_NEAR(normal_load_rear, test_values.expected_normal_load_rear,
+                test_values.tolerance);
+  }
+
+  // Tests the lateral tire forces on the front and rear tires based on the
+  // expected values contained in the input struct.
+  void TestLateralTireForce(TestValues test_values) {
+    // Compute the slip angles of the tires to be used in the lateral force
+    // calculation.
+    const double tire_slip_angle_front = test_car_->CalcTireSlip(
+        *continuous_state(), *test_car_params_, test_values.steer_angle,
+        DynamicBicycleCar<double>::Tire::kFrontTire);
+    const double tire_slip_angle_rear = test_car_->CalcTireSlip(
+        *continuous_state(), *test_car_params_, test_values.steer_angle,
+        DynamicBicycleCar<double>::Tire::kRearTire);
+
+    // Compute the normal forces on the tires to be used in the lateral force
+    // calculation.
+    const double normal_load_front = test_car_->CalcNormalTireForce(
+        *test_car_params_, test_values.f_Cp_x,
+        DynamicBicycleCar<double>::Tire::kFrontTire);
+    const double normal_load_rear = test_car_->CalcNormalTireForce(
+        *test_car_params_, test_values.f_Cp_x,
+        DynamicBicycleCar<double>::Tire::kRearTire);
+
+    // Compute the lateral forces on the tires and compare against expected
+    // values.
+    const double lateral_force_front = test_car_->CalcLateralTireForce(
+        tire_slip_angle_front, test_car_params_->c_alpha_f(), normal_load_front,
+        test_car_params_->mu());
+    const double lateral_force_rear = test_car_->CalcLateralTireForce(
+        tire_slip_angle_rear, test_car_params_->c_alpha_r(), normal_load_rear,
+        test_car_params_->mu());
+
+    EXPECT_NEAR(lateral_force_front, test_values.expected_lateral_force_front,
+                test_values.tolerance);
+    EXPECT_NEAR(lateral_force_rear, test_values.expected_lateral_force_rear,
+                test_values.tolerance);
+  }
+
+  // Test the computation of the state derivatives based on the expected values
+  // contained in the input struct.
+  void TestCalcDerivatives(TestValues test_values) {
+    test_car_->CalcTimeDerivatives(*context_, derivatives_.get());
+
+    EXPECT_NEAR(state_derivatives()->p_LoCp_x(), test_values.expected_v_LCp_x,
+                test_values.tolerance);
+    EXPECT_NEAR(state_derivatives()->p_LoCp_y(), test_values.expected_v_LCp_y,
+                test_values.tolerance);
+    EXPECT_NEAR(state_derivatives()->yaw_LC(), test_values.expected_yawDt_LC,
+                test_values.tolerance);
+    EXPECT_NEAR(state_derivatives()->v_LCp_x(), test_values.expected_vDt_LCp_x,
+                test_values.tolerance);
+    EXPECT_NEAR(state_derivatives()->v_LCp_y(), test_values.expected_vDt_LCp_y,
+                test_values.tolerance);
+    EXPECT_NEAR(state_derivatives()->yawDt_LC(), test_values.expected_yawDDt_LC,
+                test_values.tolerance);
+  }
+
+  std::unique_ptr<DynamicBicycleCar<double>>
+      test_car_;  // This is the model we are testing.
+  std::unique_ptr<DynamicBicycleCarParams<double>> test_car_params_;
+  std::unique_ptr<drake::systems::Context<double>> context_;
+  std::unique_ptr<drake::systems::SystemOutput<double>> output_;
+  std::unique_ptr<drake::systems::ContinuousState<double>> derivatives_;
+  std::unique_ptr<drake::systems::SystemOutput<double>> system_output_;
+};
+
+TEST_F(DynamicBicycleCarTest, Construction) {
+  // Test that the system has one input port and one output port.
+  EXPECT_EQ(1, test_car_->get_num_input_ports());
+  EXPECT_EQ(1, test_car_->get_num_output_ports());
+
+  // Test if the input and output ports are vectors of Eigen scalars.
+  EXPECT_EQ(drake::systems::kVectorValued,
+            test_car_->get_input_port().get_data_type());
+  EXPECT_EQ(drake::systems::kVectorValued,
+            test_car_->get_output_port().get_data_type());
+}
+
+// Tests whether DynamicBicycleCar of type DynamicBicycleCar<double> can be
+// converted to use AutoDiffXd as its scalar type.
+TEST_F(DynamicBicycleCarTest, ToAutoDiff) {
+  EXPECT_TRUE(is_autodiffxd_convertible(*test_car_));
+}
+
+// Tests whether DynamicBicycleCar of type DynamicBicycleCar<double> can be
+// converted to use symbolic::Expression as its scalar type.
+TEST_F(DynamicBicycleCarTest, ToSymbolic) {
+  EXPECT_TRUE(is_symbolic_convertible(*test_car_));
+}
+
+// Tests to make sure the inputs don't directly pass to the outputs.
+TEST_F(DynamicBicycleCarTest, DirectFeedthrough) {
+  EXPECT_FALSE(test_car_->HasAnyDirectFeedthrough());
+}
+
+// Test that the state is passed through to the output.
+TEST_F(DynamicBicycleCarTest, Output) {
+  // Set the system to have an arbitrary state.
+  Vector6<double> test_state;
+  test_state << 1.0, 3.0, 5.0, 2.0, 4.0, 6.0;
+  continuous_state()->SetFromVector(test_state);
+
+  test_car_->CalcOutput(*context_, system_output_.get());
+
+  const DynamicBicycleCarState<double>* bike_out =
+      dynamic_cast<const DynamicBicycleCarState<double>*>(
+          system_output_->get_vector_data(0));
+
+  EXPECT_NE(nullptr, bike_out);
+
+  EXPECT_EQ(1.0, bike_out->p_LoCp_x());
+  EXPECT_EQ(3.0, bike_out->p_LoCp_y());
+  EXPECT_EQ(5.0, bike_out->yaw_LC());
+  EXPECT_EQ(2.0, bike_out->v_LCp_x());
+  EXPECT_EQ(4.0, bike_out->v_LCp_y());
+  EXPECT_EQ(6.0, bike_out->yawDt_LC());
+}
+
+// Test with constant velocity in a straight line.
+TEST_F(DynamicBicycleCarTest, StraightLineTest) {
+  TestValues test_values = GetTestValuesStraightConstV();
+
+  // Set the system to have an initial state with longitudinal velocity of
+  // 10 m/s.
+  continuous_state()->SetFromVector(Vector6<double>::Zero());
+  continuous_state()->set_v_LCp_x(test_values.v_LCp_x);
+  continuous_state()->set_yaw_LC(test_values.yaw_LC);
+
+  // Sets the input port to be pi/6 radians (~30 degrees) steering angle and
+  // zero force input.
+  context_->FixInputPort(
+      0, Vector2<double>{test_values.steer_angle, test_values.f_Cp_x});
+
+  TestTireSlipAngle(test_values);
+  TestNormalLoad(test_values);
+  TestLateralTireForce(test_values);
+  TestCalcDerivatives(test_values);
+}
+
+// Test on a curve with positive steering angle.
+TEST_F(DynamicBicycleCarTest, CurveTest) {
+  TestValues test_values = GetParamsCurve();
+
+  // Set the system to have an initial state with longitudinal velocity of
+  // 10 m/s and a heading of pi/12 radians (~15 degrees).
+  continuous_state()->SetFromVector(Vector6<double>::Zero());
+  continuous_state()->set_v_LCp_x(test_values.v_LCp_x);
+  continuous_state()->set_yaw_LC(test_values.yaw_LC);
+
+  // Sets the input port to be pi/6 radians (~30 degrees) steering angle and
+  // zero force input.
+  context_->FixInputPort(
+      0, Vector2<double>{test_values.steer_angle, test_values.f_Cp_x});
+
+  TestTireSlipAngle(test_values);
+  TestNormalLoad(test_values);
+  TestLateralTireForce(test_values);
+  TestCalcDerivatives(test_values);
+}
+
+// Test on a curve with negative steering angle.
+TEST_F(DynamicBicycleCarTest, NegativeCurveTest) {
+  TestValues test_values = GetParamsCurveNegative();
+
+  // Set the system to have an initial state with longitudinal velocity of
+  // 10 m/s and a heading of pi/12 radians (~15 degrees).
+  continuous_state()->SetFromVector(Vector6<double>::Zero());
+  continuous_state()->set_v_LCp_x(test_values.v_LCp_x);
+  continuous_state()->set_yaw_LC(test_values.yaw_LC);
+
+  // Sets the input port to be -pi/6 radians (~30 degrees) steering angle and
+  // zero force input.
+  context_->FixInputPort(
+      0, Vector2<double>{test_values.steer_angle, test_values.f_Cp_x});
+
+  TestTireSlipAngle(test_values);
+  TestNormalLoad(test_values);
+  TestLateralTireForce(test_values);
+  TestCalcDerivatives(test_values);
+}
+
+}  // namespace
+}  // namespace delphyne

--- a/test/regression/cpp/road_path_test.cc
+++ b/test/regression/cpp/road_path_test.cc
@@ -1,0 +1,188 @@
+#include "systems/road_path.h"
+
+#include <cmath>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include <drake/automotive/maliput/api/lane.h>
+#include <drake/automotive/maliput/api/lane_data.h>
+#include <drake/automotive/maliput/api/road_geometry.h>
+#include <drake/automotive/maliput/dragway/road_geometry.h>
+#include <drake/automotive/maliput/monolane/builder.h>
+#include <drake/automotive/monolane_onramp_merge.h>
+
+#include "test_utilities/eigen_matrix_compare.h"
+
+namespace delphyne {
+namespace {
+
+using drake::maliput::api::GeoPosition;
+using drake::maliput::api::JunctionId;
+using drake::maliput::api::Lane;
+using drake::maliput::api::LaneEnd;
+using drake::maliput::api::LanePosition;
+using drake::maliput::api::RoadGeometry;
+using drake::maliput::monolane::Builder;
+using drake::maliput::monolane::Connection;
+using drake::maliput::monolane::Endpoint;
+using drake::maliput::monolane::EndpointZ;
+using drake::Vector3;
+
+// The length of the straight lane segment.
+const double kStraightRoadLength{10};
+
+// The arc radius, angular displacement, and length of the curved road segment.
+const double kCurvedRoadRadius{10};
+const double kCurvedRoadTheta{M_PI_2};
+const double kCurvedRoadLength{kCurvedRoadRadius * M_PI_2};
+
+const double kTotalRoadLength{kStraightRoadLength + kCurvedRoadLength};
+const EndpointZ kEndZ{0, 0, 0, 0};  // Specifies zero elevation/super-elevation.
+
+// Build a road with two lanes in series.
+std::unique_ptr<const RoadGeometry> MakeTwoLaneRoad(bool is_opposing) {
+  Builder builder(drake::maliput::api::RBounds(-2, 2), /* lane_bounds */
+                  drake::maliput::api::RBounds(-4, 4), /* driveable_bounds */
+                  drake::maliput::api::HBounds(0, 5),  /* elevation bounds */
+                  0.01,                                /* linear tolerance */
+                  M_PI_2 / 180.0);                     /* angular_tolerance */
+  builder.Connect("0_fwd",                             /* id */
+                  Endpoint({0, 0, 0}, kEndZ),          /* start */
+                  kStraightRoadLength,                 /* length */
+                  kEndZ);                              /* z_end */
+
+  if (is_opposing) {
+    // Construct a curved segment that is directionally opposite the straight
+    // lane.
+    builder.Connect("1_rev", /* id */
+                    Endpoint({kStraightRoadLength + kCurvedRoadRadius,
+                              kCurvedRoadRadius, 1.5 * M_PI},
+                             kEndZ),                        /* start */
+                    {kCurvedRoadRadius, -kCurvedRoadTheta}, /* arc */
+                    kEndZ);                                 /* z_end */
+  } else {
+    // Construct a curved segment that is directionally confluent with the
+    // straight lane.
+    builder.Connect("1_fwd",                                      /* id */
+                    Endpoint({kStraightRoadLength, 0, 0}, kEndZ), /* start */
+                    {kCurvedRoadRadius, kCurvedRoadTheta},        /* arc */
+                    kEndZ);                                       /* z_end */
+  }
+
+  return builder.Build(
+      drake::maliput::api::RoadGeometryId("TwoLaneStretchOfRoad"));
+}
+
+const Lane* GetLaneById(const RoadGeometry& road, const std::string& lane_id) {
+  for (int i = 0; i < road.num_junctions(); ++i) {
+    if (road.junction(i)->id() == JunctionId(lane_id)) {
+      return road.junction(i)->segment(0)->lane(0);
+    }
+  }
+  throw std::runtime_error("No matching junction name in the road network");
+}
+
+static double path_radius(const Vector3<double> value) {
+  Vector3<double> result;
+  result << value(0) - kStraightRoadLength, value(1) - kCurvedRoadRadius,
+      value(2);
+  return result.norm();
+}
+
+// Tests the constructor given a sufficient number of points.
+GTEST_TEST(IdmControllerTest, ConstructOpposingSegments) {
+  const double kStepSize{0.5};
+  // Instantiate a road with opposing segments.
+  auto road_opposing = MakeTwoLaneRoad(true);
+  // Start in the straight segment and progress in the positive-s-direction.
+  const LaneDirection initial_lane_dir =
+      LaneDirection(GetLaneById(*road_opposing, "j:0_fwd"), /* lane */
+                    true);                                  /* with_s */
+  // Create a finely-discretized path with a sufficient number of segments to
+  // cover the full length.
+  const auto path =
+      RoadPath<double>(initial_lane_dir, /* initial_lane_direction */
+                       kStepSize,        /* step_size */
+                       100);             /* num_breaks */
+  ASSERT_LE(kTotalRoadLength,
+            path.get_path().end_time() - path.get_path().start_time());
+
+  // Expect the lane boundary values to match.
+  Vector3<double> expected_value{};
+  Vector3<double> actual_value{};
+  expected_value << 0., 0., 0.;
+  actual_value = path.get_path().value(0.);
+  EXPECT_TRUE(test::CompareMatrices(expected_value, actual_value, 1e-3));
+  // N.B. Using tolerance of 1e-3 to account for possible interpolation errors.
+
+  // Derive s-position of the straight road segment from the number of break
+  // point steps taken to reach  kStraightRoadLength from the end of the road.
+  const double straight_length{
+      path.get_path().start_time(std::ceil(kStraightRoadLength / kStepSize))};
+  expected_value << 10., 0., 0.;
+  actual_value = path.get_path().value(straight_length);
+  EXPECT_TRUE(test::CompareMatrices(expected_value, actual_value, 1e-3));
+
+  const double total_length{path.get_path().end_time()};
+  expected_value << 20., 10., 0.;
+  actual_value = path.get_path().value(total_length);
+  EXPECT_TRUE(test::CompareMatrices(expected_value, actual_value, 1e-3));
+
+  // Pick a few arbitrary points on the curved section, expect them to trace the
+  // arc, hence demonstrating the interpolation is working.
+  actual_value = path.get_path().value(4. / 7. * kTotalRoadLength);
+  EXPECT_NEAR(kCurvedRoadRadius, path_radius(actual_value), 1e-3);
+
+  actual_value = path.get_path().value(5. / 7. * kTotalRoadLength);
+  EXPECT_NEAR(kCurvedRoadRadius, path_radius(actual_value), 1e-3);
+
+  actual_value = path.get_path().value(6. / 7. * kTotalRoadLength);
+  EXPECT_NEAR(kCurvedRoadRadius, path_radius(actual_value), 1e-3);
+
+  // Check that the number of segments created is well below the max
+  // number specified.
+  EXPECT_GT(1000, path.get_path().get_number_of_segments());
+}
+
+GTEST_TEST(IdmControllerTest, ConstructConfluentSegments) {
+  const double kStepSize{0.5};
+  // Instantiate a road with confluent segments.
+  auto road_confluent = MakeTwoLaneRoad(false);
+  // Start in the curved segment, and progress in the negative-s-direction.
+  const LaneDirection initial_lane_dir =
+      LaneDirection(GetLaneById(*road_confluent, "j:1_fwd"), /* lane */
+                    false);                                  /* with_s */
+  // Create a finely-discretized path with a sufficient number of segments to
+  // cover the full length.
+  const auto path =
+      RoadPath<double>(initial_lane_dir, /* initial_lane_direction */
+                       kStepSize,        /* step_size */
+                       100);             /* num_breaks */
+  ASSERT_LE(kTotalRoadLength,
+            path.get_path().end_time() - path.get_path().start_time());
+
+  // Expect the lane boundary values to match.
+  Vector3<double> expected_value{};
+  Vector3<double> actual_value{};
+  expected_value << 20., 10., 0.;
+  actual_value = path.get_path().value(0.);
+  EXPECT_TRUE(test::CompareMatrices(expected_value, actual_value, 1e-3));
+
+  double total_length{path.get_path().end_time()};
+  // Derive s-position of the straight road segment from the number of break
+  // point steps taken to reach kStraightRoadLength from the start of the road.
+  double straight_length{
+      path.get_path().end_time(std::ceil(kStraightRoadLength / kStepSize))};
+  double curved_length{total_length - straight_length};
+  expected_value << 10., 0., 0.;
+  actual_value = path.get_path().value(curved_length);
+  EXPECT_TRUE(test::CompareMatrices(expected_value, actual_value, 1e-3));
+
+  expected_value << 0., 0., 0.;
+  actual_value = path.get_path().value(total_length);
+  EXPECT_TRUE(test::CompareMatrices(expected_value, actual_value, 1e-3));
+}
+
+}  // namespace
+}  // namespace delphyne

--- a/test/regression/cpp/simple_powertrain_test.cc
+++ b/test/regression/cpp/simple_powertrain_test.cc
@@ -1,0 +1,52 @@
+#include "systems/simple_powertrain.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "test_utilities/scalar_conversion.h"
+
+using std::make_unique;
+
+namespace delphyne {
+namespace {
+
+// Specify a gain and a time constant for the lag model.
+static constexpr double kPowertrainTimeConstant{0.2}; /* [s] */
+static constexpr double kPowertrainGain{5.};          /* [N] */
+
+class SimplePowertrainTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    dut_.reset(
+        new SimplePowertrain<double>(kPowertrainTimeConstant, kPowertrainGain));
+  }
+  std::unique_ptr<SimplePowertrain<double>> dut_;  //< The device under test.
+};
+
+// Verifies the supplied data can be accessed.
+TEST_F(SimplePowertrainTest, Accessors) {
+  EXPECT_EQ(kPowertrainTimeConstant, dut_->get_time_constant());
+  EXPECT_EQ(kPowertrainGain, dut_->get_gain());
+}
+
+// Verifies the correctness of the model.
+TEST_F(SimplePowertrainTest, SystemMatrices) {
+  // Check the properties of the system and the coefficients of the state and
+  // output equations.
+  EXPECT_FALSE(dut_->HasAnyDirectFeedthrough());
+  EXPECT_EQ(drake::Vector1<double>(-1. / kPowertrainTimeConstant), dut_->A());
+  EXPECT_EQ(drake::Vector1<double>(kPowertrainGain), dut_->B());
+  EXPECT_EQ(drake::Vector1<double>(1. / kPowertrainTimeConstant), dut_->C());
+}
+
+TEST_F(SimplePowertrainTest, ToAutoDiff) {
+  EXPECT_TRUE(is_autodiffxd_convertible(*dut_));
+}
+
+TEST_F(SimplePowertrainTest, ToSymbolic) {
+  EXPECT_TRUE(is_symbolic_convertible(*dut_));
+}
+
+}  // namespace
+}  // namespace delphyne


### PR DESCRIPTION
In this PR includes code and tests from automotive that we are not currently using, but porting it for completeness. There are a couple of missing things though:

- `TrivialRightOfWayStateProvider` was not ported as it is not used anywhere and in order to test it we would need to bring in code from maliput that is currently not exposed by drake (see https://github.com/RobotLocomotion/drake/tree/master/automotive/maliput/api/test_utilities).
- Automotive demo and automotive simulator, as this is what is being redefined in delphyne.
- Some LCM-related files, as we are replacing LCM with ignition transport.
- Some of the cars (e.g. `maliput_railcar`) as that is what we are replacing with the agents.

