### PR TITLE
We added -rdynamic in the past to make things work for dlopen.

### DIFF
--- a/cmake/DefaultCFlags.cmake
+++ b/cmake/DefaultCFlags.cmake
@@ -1,13 +1,3 @@
-# Note that we have to put '-rdynamic' into all of the LINK_FLAGS so that
-# we get our symbols placed into the dynamic symbol table.  This is needed so
-# that our loadable agents have access to the internal symbols from our library.
-
-# Build type link flags
-set (CMAKE_LINK_FLAGS_RELEASE " -rdynamic" CACHE INTERNAL "Link flags for release" FORCE)
-set (CMAKE_LINK_FLAGS_RELWITHDEBINFO " -rdynamic" CACHE INTERNAL "Link flags for release with debug support" FORCE)
-set (CMAKE_LINK_FLAGS_DEBUG " -rdynamic" CACHE INTERNAL "Link flags for debug" FORCE)
-set (CMAKE_LINK_FLAGS_PROFILE " -rdynamic -pg" CACHE INTERNAL "Link flags for profile" FORCE)
-
 set (CMAKE_C_FLAGS_RELEASE "")
 set (CMAKE_C_FLAGS_RELEASE "-s")
 


### PR DESCRIPTION
But since we aren't doing that anymore, we don't need the flags.
Remove them here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>