### PR TITLE
Move the XML declaration to the first line of the prius SDF.

### DIFF
--- a/media/prius/simple_prius.sdf
+++ b/media/prius/simple_prius.sdf
@@ -1,7 +1,7 @@
+<?xml version='1.0' ?>
 <!-- Note: this is a fork + simplification of
 https://github.com/RobotLocomotion/drake/blob/master/automotive/models/prius/prius.sdf
 -->
-<?xml version='1.0' ?>
 <sdf version="1.6">
   <model name="prius_1">
     <pose>0 0 0 0 0 0</pose>


### PR DESCRIPTION
The newer version of tinyxml2 in bionic is more strict and
insists that this the first thing in the file (even before
comments).  Just put it there unconditionally, as this works
on Xenial as well.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>