### PR TITLE
Fix a latent (and real) bug during destruction.

### DIFF
--- a/src/backend/ign_subscriber_system.h
+++ b/src/backend/ign_subscriber_system.h
@@ -173,9 +173,6 @@ class IgnSubscriberSystem : public drake::systems::LeafSystem<double> {
   // The topic on which to publish ign-transport messages.
   const std::string topic_name_;
 
-  // Ignition transport node.
-  ignition::transport::Node node_;
-
   // The mutex that guards last_received_message_ and received_message_count_.
   mutable std::mutex received_message_mutex_;
 
@@ -184,6 +181,14 @@ class IgnSubscriberSystem : public drake::systems::LeafSystem<double> {
 
   // A message counter that's incremented every time the handler is called.
   int received_message_count_{0};
+
+  // Ignition transport node.
+  // The ignition transport node must be declared after everything its callbacks
+  // use.  This ensures that it is constructed after everything it needs is
+  // properly setup, and destroyed before everything it needs is destroyed,
+  // avoiding a race where the callback for a subscribed topic can be called
+  // after the member variables it needs have already been destroyed.
+  ignition::transport::Node node_;
 
   // The index of the state used to access the the message.
   static constexpr int kStateIndexMessage = 0;


### PR DESCRIPTION
There's more information in the comments, but essentially it
turns out that we could have gotten one more ign-transport
callback while the ign-transport Node was being destroyed.
This isn't a big deal for ign-transport itself, but it *is*
a big deal for the callback.  If the callback was relying on
other members of the class that ignition::transport::Node
was embedded in, it could access them *after* those members
had been destroyed.  Because C++ rules guarantee the order
in which members are constructed/destructed, move the
ignition::transport::Node method to the end of the members,
ensuring it is the last thing constructed and the first thing
destructed.  This fixes the bug in my testing, while getting
rid of the hack that was there before.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>