### PR TITLE
[BUGFIX] Assigns proximity role to Prius car collision geometries.

### DIFF
--- a/src/backend/geometry_wiring.h
+++ b/src/backend/geometry_wiring.h
@@ -62,7 +62,9 @@ const drake::systems::InputPort<T>& WirePriusGeometry(
   using drake::geometry::SourceId;
   using drake::geometry::FrameId;
   using drake::geometry::GeometryFrame;
+  using drake::geometry::GeometryId;
   using drake::geometry::GeometryInstance;
+  using drake::geometry::ProximityProperties;
   using drake::systems::ConstantVectorSource;
   using drake::systems::rendering::PoseVector;
 
@@ -96,8 +98,11 @@ const drake::systems::InputPort<T>& WirePriusGeometry(
       std::make_unique<Box>(kPriusCarLength, kPriusCarWidth, kPriusCarHeight),
       "prius_bounding_box");
 
-  geometry_ids->insert(scene_graph->RegisterGeometry(
-      source_id, car_chassis_frame_id, std::move(car_bounding_box)));
+  const GeometryId car_chassis_geometry_id = scene_graph->RegisterGeometry(
+      source_id, car_chassis_frame_id, std::move(car_bounding_box));
+  scene_graph->AssignRole(
+      source_id, car_chassis_geometry_id, ProximityProperties());
+  geometry_ids->insert(car_chassis_geometry_id);
 
   // Sets up a frame pose aggregator to deal with the
   // drake::systems::rendering::PoseVector to drake::geometry::FramePoseVector

--- a/test/regression/cpp/agent_simulation_builder_test.cc
+++ b/test/regression/cpp/agent_simulation_builder_test.cc
@@ -721,7 +721,7 @@ TEST_F(AgentSimulationTest, TestGetCollisions) {
   // Checks that there was a collision and that the colliding
   // agents are the expected ones.
   agent_collisions = simulation->GetCollisions();
-  EXPECT_EQ(agent_collisions.size(), 1);
+  ASSERT_EQ(agent_collisions.size(), 1);
   const AgentBaseCollision<double>& collision = agent_collisions.front();
 
   // Cannot make any assumption regarding pair order, see


### PR DESCRIPTION
This pull request fixes broken collision detection after latest Drake update. 

Long story short, `SceneGraph` now supports roles for the geometries associated with it and only those tagged with the proximity role will ever be accounted for during collision computations.