### PR TITLE
Exports DELPHYNE_PACKAGE_PATH when running tests in CI

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -15,6 +15,7 @@ then
   DELPHYNE_BUILD_DIR=$DELPHYNE_SOURCE_DIR/build/delphyne
   DELPHYNE_INSTALL_DIR=$DELPHYNE_SOURCE_DIR/install
   export DELPHYNE_RESOURCE_ROOT=$DELPHYNE_INSTALL_DIR/share/delphyne
+  export DELPHYNE_PACKAGE_PATH=$DELPHYNE_INSTALL_DIR/share/drake/automotive/models
   export LD_LIBRARY_PATH=$DELPHYNE_INSTALL_DIR/lib
 else
   # If `-jenkins` was NOT defined, it assumes the


### PR DESCRIPTION
Precisely what the title says. Since we're already exporting some of the environment variables set in the installed `setup.bash` again for testing, I just extended the list (I presume we're not sourcing because we don't want to force an installation?).

This pull request should fix the failing tests in CI.