### PR TITLE
Make the MOBIL car overshoot corners less.

### DIFF
--- a/src/gen/pure_pursuit_params.h
+++ b/src/gen/pure_pursuit_params.h
@@ -53,7 +53,7 @@ class PurePursuitParams final : public drake::systems::BasicVector<T> {
   /// Default constructor.  Sets all rows to their default value:
   /// @arg @c s_lookahead defaults to 15.0 m.
   PurePursuitParams() : drake::systems::BasicVector<T>(K::kNumCoordinates) {
-    this->set_s_lookahead(15.0);
+    this->set_s_lookahead(10.0);
   }
 
   // Note: It's safe to implement copy and move because this class is final.


### PR DESCRIPTION
While investigating
https://github.com/ToyotaResearchInstitute/delphyne/issues/573,
I found that the MOBIL car overshoots lanes because of the
distance it looks ahead in the pure pursuit controller (which
is responsible for steering).  In mathematical terms, the
calculation for the curvature looks like:

curvature = 2.0 * delta_r / lookahead^2

So reducing the lookahead increases the amount of curvature we
can handle at each iteration.  This has the effect of letting
the pursuit controller keep much closer to the lanes.  This
also has the knock-on effect of reducing the number of collisions
we have in the gazoo, which is the goal of
https://github.com/ToyotaResearchInstitute/delphyne/issues/545.
Previous to this patch, it took something like 5 minutes to hit
a collision, where now it takes about 20 minutes.

There is a downside to this tuning, however.  The gazoo scenario
(for instance) somewhat relies on the MOBIL cars going out of their
lanes to actually force them to change lanes.  By reducing the
amount these cars "drift", it makes them change lanes less
often.  Thus, we can't reduce the lookahead too far, otherwise
the vehicles bind very tightly to their lanes (and actually
have some other weird side-effects).  The new value of 10.0
seems to be a decent compromise between these facets, but still
causes less lane changing that the default of 15.0.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>