### PR TITLE
Fix warnings from drake upgrade.

### DIFF
--- a/src/systems/rail_follower.cc
+++ b/src/systems/rail_follower.cc
@@ -19,7 +19,7 @@
 #include <drake/common/cond.h>
 #include <drake/common/drake_assert.h>
 #include <drake/math/rotation_matrix.h>
-#include <drake/multibody/multibody_tree/math/spatial_velocity.h>
+#include <drake/multibody/math/spatial_velocity.h>
 #include <drake/systems/framework/basic_vector.h>
 #include <drake/systems/framework/value.h>
 #include <drake/systems/framework/vector_base.h>

--- a/src/systems/trajectory.h
+++ b/src/systems/trajectory.h
@@ -12,7 +12,7 @@
 #include <drake/common/trajectories/piecewise_quaternion.h>
 #include <drake/math/quaternion.h>
 #include <drake/math/roll_pitch_yaw.h>
-#include <drake/multibody/multibody_tree/math/spatial_velocity.h>
+#include <drake/multibody/math/spatial_velocity.h>
 
 namespace delphyne {
 

--- a/test/regression/cpp/idm_controller_test.cc
+++ b/test/regression/cpp/idm_controller_test.cc
@@ -4,7 +4,7 @@
 
 #include "drake/automotive/maliput/dragway/road_geometry.h"
 #include "drake/common/eigen_types.h"
-#include "drake/multibody/multibody_tree/math/spatial_velocity.h"
+#include "drake/multibody/math/spatial_velocity.h"
 
 #include "test_utilities/eigen_matrix_compare.h"
 #include "test_utilities/scalar_conversion.h"


### PR DESCRIPTION
The latest drake upgrade introduced warnings like:

'#warning This header is deprecated; use drake/multibody/math/spatial_velocity.h instead'

Fix that here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>