### PR TITLE
Fixes car direction evaluation within the TrafficPoseSelector system

### DIFF
--- a/src/systems/traffic_pose_selector.cc
+++ b/src/systems/traffic_pose_selector.cc
@@ -156,10 +156,9 @@ LaneEnd FindLaneEnd(const Lane* lane, const LanePositionT<T>& lane_position,
   // canonical direction.
   const Quaternion<double> lane_rotation =
       lane->GetOrientation(lane_position.MakeDouble()).quat();
-  // The dot product of two quaternions is the cosine of half the angle between
-  // the two rotations. Given two quaternions q₀, q₁ and letting θ be the angle
-  // difference between them, then -π/2 ≤ θ ≤ π/2 iff q₀.q₁ ≥ √2/2.
-  const double angle = std::abs(lane_rotation.angularDistance(
+  // It is assumed that the vehicle is going in the lane's direction if
+  // the angular distance θ between their headings is -π/2 ≤ θ ≤ π/2.
+  const double angle = std::fabs(lane_rotation.angularDistance(
       Quaternion<double>(drake::ExtractDoubleOrThrow(rotation.w()),
                          drake::ExtractDoubleOrThrow(rotation.x()),
                          drake::ExtractDoubleOrThrow(rotation.y()),


### PR DESCRIPTION
Precisely what the title says. The naive angular distance computation would sometimes result in the MOBIL planner and/or the IDM controller looking in the wrong lane direction. 

I wonder how this remain unnoticed for such a long time.