### PR TITLE
Repeated simulation pausing/stepping misbehaves fix #589

### DIFF
--- a/src/backend/simulation_runner.cc
+++ b/src/backend/simulation_runner.cc
@@ -383,9 +383,12 @@ void SimulationRunner::SendWorldStats() {
 void SimulationRunner::ProcessWorldControlMessage(
     const ignition::msgs::WorldControl& msg) {
   if (msg.has_pause()) {
-    if (msg.pause()) {
+    /* If we press the play-pause button quickly,
+    more than one play/pause message will be sent
+    so we just ignore it. */
+    if (msg.pause() && !IsSimulationPaused()) {
       PauseSimulation();
-    } else {
+    } else if (IsSimulationPaused()) {
       UnpauseSimulation();
     }
   } else if (msg.has_step() && msg.step()) {


### PR DESCRIPTION
Ignition sends a message using a non blocking call when Play/Pause/Step buttons are pressed, if we press those buttons quickly, we can send the same pause/play/step button more than once, which ends up in aborting the simulation. I don't consider this an issue from ignition, since those messages are not relevant to wait for a response, it's better to handle this minor issue from delphyne rather than making a pr to ignition that could have some impact in performance for using a blocking call.