### PR TITLE
Update backend to deal with Drake API deprecations

### DIFF
--- a/src/backend/geometry_utilities.h
+++ b/src/backend/geometry_utilities.h
@@ -128,9 +128,12 @@ template <typename T>
 drake::lcmt_viewer_load_robot
 BuildLoadMessage(const drake::geometry::SceneGraph<T>& scene_graph) {
   drake::lcm::DrakeMockLcm lcm;
+  drake::lcm::Subscriber<drake::lcmt_viewer_load_robot> sub(
+      &lcm, "DRAKE_VIEWER_LOAD_ROBOT");
   DispatchLoadMessage(scene_graph, &lcm);
-  return lcm.DecodeLastPublishedMessageAs<
-    drake::lcmt_viewer_load_robot>("DRAKE_VIEWER_LOAD_ROBOT");
+  constexpr int kTimeoutMS{0};
+  lcm.HandleSubscriptions(kTimeoutMS);
+  return sub.message();
 }
 
 drake::lcmt_viewer_load_robot


### PR DESCRIPTION
Precisely what the title says. Goes hand in hand with https://github.com/ToyotaResearchInstitute/dsim-repos-index/pull/21.