### PR TITLE
Normalize dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ endif()
 
 ament_environment_hooks(setup.bash.in)
 ament_export_dependencies(ament_cmake)
-ament_export_dependencies(drake)
+ament_export_dependencies(drake_vendor)
 ament_export_dependencies(malidrive)
 ament_export_interfaces(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)
 

--- a/package.xml
+++ b/package.xml
@@ -38,14 +38,14 @@
   <build_depend>uuid</build_depend>
   <build_depend>unzip</build_depend>
 
-  <build_depend>drake</build_depend>
+  <build_depend>drake_vendor</build_depend>
   <build_depend>ignition-common2</build_depend>
   <build_depend>ignition-math5</build_depend>
   <build_depend>ignition-msgs2</build_depend>
   <build_depend>ignition-transport5</build_depend>
   <build_depend>malidrive</build_depend>
 
-  <build_export_depend>drake</build_export_depend>
+  <build_export_depend>drake_vendor</build_export_depend>
   <build_export_depend>ignition-common2</build_export_depend>
   <build_export_depend>ignition-math5</build_export_depend>
   <build_export_depend>ignition-msgs2</build_export_depend>


### PR DESCRIPTION
This pull request is a one of a set to normalize dependencies when it comes to drake_vendor and pybind11.

Connected to https://github.com/ToyotaResearchInstitute/dsim-repos-index/pull/36.