### PR TITLE
Add clang format as a test dependency in package xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -54,6 +54,7 @@
   <build_export_depend>malidrive</build_export_depend>
 
   <exec_depend>ament_cmake</exec_depend>
+  <test_depend>ament_clang_format</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Clang format was missing from package.xml to run one of the test