### PR TITLE
Add pybind11-dev as a package.xml dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -45,6 +45,7 @@
   <depend>multilane</depend>
   <depend>maliput-utilities</depend>
   <depend>dragway</depend>
+  <depend>pybind11-dev</depend>
 
   <build_export_depend>drake_vendor</build_export_depend>
   <build_export_depend>ignition-common3</build_export_depend>


### PR DESCRIPTION
Connected to https://github.com/ToyotaResearchInstitute/dsim-repos-index/pull/111.