### PR TITLE
Uses maliput_copyable instead of drake_copyable.

### DIFF
--- a/include/delphyne/macros.h
+++ b/include/delphyne/macros.h
@@ -5,7 +5,8 @@
 #include <string>
 
 #include <drake/common/drake_assert.h>
-#include <drake/common/drake_copyable.h>
+
+#include <maliput/common/maliput_copyable.h>
 
 #if defined(__GNUC__)
 #define DELPHYNE_DEPRECATED(version) __attribute__((deprecated))
@@ -41,7 +42,7 @@
 /// };
 /// </pre>
 /// */
-#define DELPHYNE_NO_COPY_NO_MOVE_NO_ASSIGN(class) DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(class)
+#define DELPHYNE_NO_COPY_NO_MOVE_NO_ASSIGN(class) MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(class)
 
 /// \def STR_SIMPLE
 /// Internal stringify a token

--- a/include/delphyne/mi6/diagram_bundle.h
+++ b/include/delphyne/mi6/diagram_bundle.h
@@ -12,12 +12,13 @@
 #include <type_traits>
 #include <utility>
 
-#include <drake/common/drake_copyable.h>
 #include <drake/systems/framework/diagram.h>
 #include <drake/systems/framework/diagram_builder.h>
 #include <drake/systems/framework/framework_common.h>  // OutputPortIndex
 #include <drake/systems/framework/input_port.h>
 #include <drake/systems/framework/output_port.h>
+
+#include <maliput/common/maliput_copyable.h>
 
 #include "delphyne/macros.h"
 #include "delphyne/types.h"
@@ -52,7 +53,7 @@ class NamedPortSystem : public Base {
  public:
   static_assert(std::is_base_of<drake::systems::System<T>, Base>::value, "Only a System can have their ports mapped.");
 
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(NamedPortSystem);
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(NamedPortSystem);
 
   template <typename... Args>
   explicit NamedPortSystem(Args... args) : Base(std::forward<Args>(args)...) {}

--- a/src/agents/mobil_car.h
+++ b/src/agents/mobil_car.h
@@ -12,8 +12,8 @@
 #include <memory>
 #include <string>
 
-#include <drake/common/drake_copyable.h>
 #include <maliput/api/road_geometry.h>
+#include <maliput/common/maliput_copyable.h>
 
 // public headers
 #include "delphyne/mi6/agent_base_blueprint.h"

--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(
     visualization
     drake::drake
     maliput::api
+    maliput::common
     maliput-utilities::maliput-utilities
     ignition-common3::ignition-common3
     ignition-transport5::core
@@ -62,8 +63,14 @@ add_executable(replayer
   replayer.cc
 )
 
+ament_target_dependencies(replayer
+  PUBLIC
+  "maliput"
+)
+
 target_link_libraries(replayer
   PRIVATE
+    maliput::common
     protobuf_messages
     public_headers
     ${IGNITION-COMMON_LIBRARIES}

--- a/src/backend/frame_pose_aggregator.h
+++ b/src/backend/frame_pose_aggregator.h
@@ -4,12 +4,13 @@
 
 #include <vector>
 
-#include <drake/common/drake_copyable.h>
 #include <drake/geometry/frame_kinematics_vector.h>
 #include <drake/geometry/geometry_ids.h>
 #include <drake/systems/framework/context.h>
 #include <drake/systems/framework/input_port.h>
 #include <drake/systems/framework/leaf_system.h>
+
+#include <maliput/common/maliput_copyable.h>
 
 namespace delphyne {
 
@@ -22,7 +23,7 @@ namespace delphyne {
 template <typename T>
 class FramePoseAggregator : public drake::systems::LeafSystem<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FramePoseAggregator)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(FramePoseAggregator)
 
   FramePoseAggregator();
 

--- a/src/systems/bicycle_car.h
+++ b/src/systems/bicycle_car.h
@@ -6,8 +6,9 @@
 
 #include <Eigen/Geometry>
 
-#include <drake/common/drake_copyable.h>
 #include <drake/systems/framework/leaf_system.h>
+
+#include <maliput/common/maliput_copyable.h>
 
 #include "gen/bicycle_car_parameters.h"
 #include "gen/bicycle_car_state.h"
@@ -66,7 +67,7 @@ namespace delphyne {
 template <typename T>
 class BicycleCar final : public drake::systems::LeafSystem<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BicycleCar)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(BicycleCar)
 
   /// Default constructor.
   BicycleCar();

--- a/src/systems/curve2.h
+++ b/src/systems/curve2.h
@@ -9,7 +9,8 @@
 #include <Eigen/Dense>
 
 #include "drake/common/autodiffxd_make_coherent.h"
-#include "drake/common/drake_copyable.h"
+
+#include "maliput/common/maliput_copyable.h"
 
 namespace delphyne {
 
@@ -30,7 +31,7 @@ namespace delphyne {
 template <typename T>
 class Curve2 {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Curve2)
+  MALIPUT_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Curve2)
 
   /// A two-dimensional Cartesian point that is alignment-safe.
   typedef Eigen::Matrix<double, 2, 1, Eigen::DontAlign> Point2;

--- a/src/systems/driving_command_mux.h
+++ b/src/systems/driving_command_mux.h
@@ -2,8 +2,9 @@
 
 #pragma once
 
-#include <drake/common/drake_copyable.h>
 #include <drake/systems/framework/leaf_system.h>
+
+#include <maliput/common/maliput_copyable.h>
 
 #include "gen/driving_command.h"
 
@@ -33,7 +34,7 @@ namespace delphyne {
 template <typename T>
 class DrivingCommandMux : public drake::systems::LeafSystem<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DrivingCommandMux)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(DrivingCommandMux)
 
   /// Constructs a %DrivingCommandMux with two scalar-valued input ports, and
   /// one output port containing a DrivingCommand<T>.

--- a/src/systems/dynamic_bicycle_car.h
+++ b/src/systems/dynamic_bicycle_car.h
@@ -4,6 +4,8 @@
 
 #include <drake/systems/framework/leaf_system.h>
 
+#include <maliput/common/maliput_copyable.h>
+
 #include "gen/dynamic_bicycle_car_input.h"
 #include "gen/dynamic_bicycle_car_params.h"
 #include "gen/dynamic_bicycle_car_state.h"
@@ -69,7 +71,7 @@ namespace delphyne {
 template <typename T>
 class DynamicBicycleCar final : public drake::systems::LeafSystem<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DynamicBicycleCar);
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(DynamicBicycleCar);
 
   /// Default constructor.
   DynamicBicycleCar();

--- a/src/systems/idm_controller.h
+++ b/src/systems/idm_controller.h
@@ -7,12 +7,12 @@
 
 #include <Eigen/Geometry>
 
-#include <drake/common/drake_copyable.h>
 #include <drake/systems/framework/leaf_system.h>
 #include <drake/systems/rendering/pose_bundle.h>
 #include <drake/systems/rendering/pose_vector.h>
 #include <maliput/api/lane_data.h>
 #include <maliput/api/road_geometry.h>
+#include <maliput/common/maliput_copyable.h>
 
 #include "gen/idm_planner_parameters.h"
 #include "systems/calc_ongoing_road_position.h"
@@ -55,7 +55,7 @@ namespace delphyne {
 template <typename T>
 class IDMController : public drake::systems::LeafSystem<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IDMController)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(IDMController)
 
   /// Constructor.
   /// @param road The pre-defined RoadGeometry.

--- a/src/systems/idm_planner.h
+++ b/src/systems/idm_planner.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <drake/common/drake_copyable.h>
+#include <maliput/common/maliput_copyable.h>
 
 #include "gen/idm_planner_parameters.h"
 
@@ -41,7 +41,7 @@ namespace delphyne {
 template <typename T>
 class IdmPlanner {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IdmPlanner)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(IdmPlanner)
   IdmPlanner() = delete;
 
   /// Evaluates the IDM equation for the chosen planner parameters @p params,

--- a/src/systems/lane_direction.h
+++ b/src/systems/lane_direction.h
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include <maliput/api/lane.h>
+#include <maliput/common/maliput_copyable.h>
 
 namespace delphyne {
 
@@ -12,7 +13,7 @@ namespace delphyne {
 /// direction in which it is moving. A MaliputRailcar can either travel in the
 /// increasing-`s` direction or in the decreasing-`s` direction.
 struct LaneDirection {
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LaneDirection)
+  MALIPUT_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LaneDirection)
 
   /// Default constructor.
   LaneDirection() {}

--- a/src/systems/mobil_planner.h
+++ b/src/systems/mobil_planner.h
@@ -9,12 +9,12 @@
 
 #include <Eigen/Geometry>
 
-#include <drake/common/drake_copyable.h>
 #include <drake/systems/framework/leaf_system.h>
 #include <drake/systems/rendering/pose_bundle.h>
 #include <drake/systems/rendering/pose_vector.h>
 #include <maliput/api/lane.h>
 #include <maliput/api/road_geometry.h>
+#include <maliput/common/maliput_copyable.h>
 
 #include "gen/idm_planner_parameters.h"
 #include "gen/mobil_planner_parameters.h"
@@ -88,7 +88,7 @@ class MobilPlanner : public drake::systems::LeafSystem<T> {
  public:
   typedef typename std::map<AheadOrBehind, const ClosestPose<T>> ClosestPoses;
 
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MobilPlanner)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(MobilPlanner)
 
   /// A constructor that initializes the MOBIL planner.
   /// @param road The pre-defined RoadGeometry.

--- a/src/systems/pure_pursuit.h
+++ b/src/systems/pure_pursuit.h
@@ -2,9 +2,9 @@
 
 #pragma once
 
-#include <drake/common/drake_copyable.h>
 #include <drake/systems/rendering/pose_vector.h>
 #include <maliput/api/lane_data.h>
+#include <maliput/common/maliput_copyable.h>
 
 #include "gen/pure_pursuit_params.h"
 #include "gen/simple_car_params.h"
@@ -34,7 +34,7 @@ namespace delphyne {
 template <typename T>
 class PurePursuit {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PurePursuit)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(PurePursuit)
   PurePursuit() = delete;
 
   /// Evaluates the required steering angle in radians using the pure-pursuit

--- a/src/systems/pure_pursuit_controller.h
+++ b/src/systems/pure_pursuit_controller.h
@@ -6,10 +6,10 @@
 
 #include <Eigen/Geometry>
 
-#include <drake/common/drake_copyable.h>
 #include <drake/systems/framework/leaf_system.h>
 #include <drake/systems/framework/scalar_conversion_traits.h>
 #include <drake/systems/rendering/pose_vector.h>
+#include <maliput/common/maliput_copyable.h>
 
 #include "gen/pure_pursuit_params.h"
 #include "gen/simple_car_params.h"
@@ -40,7 +40,7 @@ namespace delphyne {
 template <typename T>
 class PurePursuitController : public drake::systems::LeafSystem<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PurePursuitController)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(PurePursuitController)
 
   /// Constructor.
   PurePursuitController();

--- a/src/systems/rail_follower.h
+++ b/src/systems/rail_follower.h
@@ -6,12 +6,12 @@
 #include <optional>
 #include <vector>
 
-#include <drake/common/drake_copyable.h>
 #include <drake/systems/framework/leaf_system.h>
 #include <drake/systems/framework/system_symbolic_inspector.h>
 #include <drake/systems/rendering/frame_velocity.h>
 #include <drake/systems/rendering/pose_vector.h>
 #include <maliput/api/lane.h>
+#include <maliput/common/maliput_copyable.h>
 
 #include "gen/rail_follower_params.h"
 #include "gen/rail_follower_state.h"
@@ -64,7 +64,7 @@ namespace delphyne {
 template <typename T>
 class RailFollower final : public drake::systems::LeafSystem<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RailFollower)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(RailFollower)
   /// Defines a distance that is "close enough" to the end of a lane for the
   /// modelled entity to transition to an ongoing branch. The primary
   /// constraint on the selection of this variable is the application's

--- a/src/systems/road_path.h
+++ b/src/systems/road_path.h
@@ -2,10 +2,10 @@
 
 #pragma once
 
-#include <drake/common/drake_copyable.h>
 #include <drake/common/eigen_types.h>
 #include <drake/common/trajectories/piecewise_polynomial.h>
 #include <maliput/api/road_geometry.h>
+#include <maliput/common/maliput_copyable.h>
 
 #include "systems/lane_direction.h"
 
@@ -30,7 +30,7 @@ namespace delphyne {
 template <typename T>
 class RoadPath {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RoadPath)
+  MALIPUT_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RoadPath)
 
   /// Constructs a single RoadPath from a sequence of Maliput lanes based on the
   /// following parameters:

--- a/src/systems/simple_car.h
+++ b/src/systems/simple_car.h
@@ -4,10 +4,10 @@
 
 #include <memory>
 
-#include <drake/common/drake_copyable.h>
 #include <drake/systems/framework/leaf_system.h>
 #include <drake/systems/rendering/frame_velocity.h>
 #include <drake/systems/rendering/pose_vector.h>
+#include <maliput/common/maliput_copyable.h>
 
 #include "gen/driving_command.h"
 #include "gen/simple_car_params.h"
@@ -53,7 +53,7 @@ namespace delphyne {
 template <typename T>
 class SimpleCar2 final : public drake::systems::LeafSystem<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SimpleCar2)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(SimpleCar2)
 
   /// @brief Initialise the background context on construction.
   ///

--- a/src/systems/simple_powertrain.h
+++ b/src/systems/simple_powertrain.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <drake/systems/primitives/linear_system.h>
+#include <maliput/common/maliput_copyable.h>
 
 namespace delphyne {
 
@@ -30,7 +31,7 @@ namespace delphyne {
 template <typename T>
 class SimplePowertrain final : public drake::systems::LinearSystem<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SimplePowertrain);
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(SimplePowertrain);
 
   /// Constructs a simple powertrain model, specified via a fixed time-constant
   /// and scalar gain.  The inputs are as follows:

--- a/src/systems/speed_system.h
+++ b/src/systems/speed_system.h
@@ -16,7 +16,7 @@ namespace delphyne {
 template <typename T>
 class SpeedSystem final : public drake::systems::LeafSystem<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SpeedSystem)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(SpeedSystem)
 
   /// Default constructor.
   SpeedSystem() {

--- a/src/systems/traffic_pose_selector.h
+++ b/src/systems/traffic_pose_selector.h
@@ -8,12 +8,12 @@
 
 #include <Eigen/Geometry>
 
-#include <drake/common/drake_copyable.h>
 #include <drake/systems/rendering/pose_bundle.h>
 #include <drake/systems/rendering/pose_vector.h>
 #include <maliput/api/lane.h>
 #include <maliput/api/lane_data.h>
 #include <maliput/api/road_geometry.h>
+#include <maliput/common/maliput_copyable.h>
 
 #include "systems/lane_direction.h"
 #include "systems/road_odometry.h"
@@ -65,7 +65,7 @@ enum class RoadPositionStrategy { kCache, kExhaustiveSearch };
 template <typename T>
 class TrafficPoseSelector {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TrafficPoseSelector)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(TrafficPoseSelector)
 
   TrafficPoseSelector() = delete;
 

--- a/src/systems/trajectory.h
+++ b/src/systems/trajectory.h
@@ -7,12 +7,13 @@
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
 
-#include <drake/common/drake_copyable.h>
 #include <drake/common/trajectories/piecewise_polynomial.h>
 #include <drake/common/trajectories/piecewise_quaternion.h>
 #include <drake/math/quaternion.h>
 #include <drake/math/roll_pitch_yaw.h>
 #include <drake/multibody/math/spatial_velocity.h>
+
+#include <maliput/common/maliput_copyable.h>
 
 namespace delphyne {
 
@@ -23,7 +24,7 @@ namespace delphyne {
 /// respect to W.
 class PoseVelocity final {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PoseVelocity)
+  MALIPUT_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PoseVelocity)
 
   /// Default constructor.  Sets rotation to an identity transform and all
   /// translation and velocity components to zero.
@@ -82,7 +83,7 @@ class PoseVelocity final {
 /// match the input pose data exactly.
 class Trajectory final {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Trajectory)
+  MALIPUT_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Trajectory)
 
   /// An identifier for the type of valid types of interpolation used in
   /// evaluating the translational component of a Trajectory.  These types

--- a/src/systems/trajectory_follower.h
+++ b/src/systems/trajectory_follower.h
@@ -4,11 +4,12 @@
 
 #include <Eigen/Geometry>
 
-#include <drake/common/drake_copyable.h>
 #include <drake/common/extract_double.h>
 #include <drake/systems/framework/leaf_system.h>
 #include <drake/systems/rendering/frame_velocity.h>
 #include <drake/systems/rendering/pose_vector.h>
+
+#include <maliput/common/maliput_copyable.h>
 
 #include "gen/simple_car_state.h"
 #include "systems/trajectory.h"
@@ -46,7 +47,7 @@ namespace delphyne {
 template <typename T>
 class TrajectoryFollower final : public drake::systems::LeafSystem<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TrajectoryFollower)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(TrajectoryFollower)
 
   /// Constructs a TrajectoryFollower system that traces a given Trajectory.
   ///

--- a/src/systems/vector_source.h
+++ b/src/systems/vector_source.h
@@ -32,7 +32,7 @@ namespace delphyne {
 template <typename T>
 class VectorSource final : public drake::systems::LeafSystem<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(VectorSource)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(VectorSource)
 
   explicit VectorSource(T defaultval) {
     output_port_index_ =

--- a/src/translations/CMakeLists.txt
+++ b/src/translations/CMakeLists.txt
@@ -19,15 +19,21 @@ target_include_directories(
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
 )
 
+ament_target_dependencies(translations
+	PUBLIC
+		"maliput"
+)
+
 target_link_libraries(translations
   PUBLIC
-    public_headers
-    protobuf
-    protobuf_messages
     drake::drake
     ignition-common3::ignition-common3
     ignition-msgs2::ignition-msgs2
     ignition-transport5::ignition-transport5
+    maliput::common
+    protobuf
+    protobuf_messages
+    public_headers
 )
 
 install(TARGETS translations

--- a/src/utility/CMakeLists.txt
+++ b/src/utility/CMakeLists.txt
@@ -21,10 +21,16 @@ target_include_directories(
     ${LIBZIP_INCLUDE_DIRS}
 )
 
+ament_target_dependencies(utility
+	PUBLIC
+		"maliput"
+)
+
 target_link_libraries(utility
   PUBLIC
-    public_headers
     ignition-common3::ignition-common3
+    maliput::common
+    public_headers
     ${LIBZIP_LIBRARIES}
 )
 

--- a/src/visualization/car_vis.h
+++ b/src/visualization/car_vis.h
@@ -7,6 +7,8 @@
 #include "drake/lcmt_viewer_link_data.hpp"
 #include "drake/systems/rendering/pose_bundle.h"
 
+#include <maliput/common/maliput_copyable.h>
+
 namespace delphyne {
 
 /// CarVis is a base class that provides visualization geometries and their
@@ -20,7 +22,7 @@ namespace delphyne {
 template <typename T>
 class CarVis {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(CarVis)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(CarVis)
 
   /// The constructor.
   ///

--- a/src/visualization/car_vis_applicator.h
+++ b/src/visualization/car_vis_applicator.h
@@ -4,11 +4,12 @@
 #include <map>
 #include <memory>
 
-#include <drake/common/drake_copyable.h>
 #include <drake/lcmt_viewer_load_robot.hpp>
 #include <drake/systems/framework/leaf_system.h>
 #include <drake/systems/rendering/pose_bundle.h>
 #include <drake/systems/rendering/pose_vector.h>
+
+#include <maliput/common/maliput_copyable.h>
 
 #include "visualization/car_vis.h"
 
@@ -43,7 +44,7 @@ namespace delphyne {
 template <typename T>
 class CarVisApplicator : public drake::systems::LeafSystem<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(CarVisApplicator)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(CarVisApplicator)
 
   CarVisApplicator();
   ~CarVisApplicator() override {}

--- a/src/visualization/prius_vis.h
+++ b/src/visualization/prius_vis.h
@@ -6,13 +6,14 @@
 #include <string>
 #include <vector>
 
-#include <drake/common/drake_copyable.h>
 #include <drake/geometry/scene_graph.h>
 #include <drake/lcmt_viewer_link_data.hpp>
 #include <drake/multibody/plant/multibody_plant.h>
 #include <drake/multibody/tree/multibody_tree_indexes.h>
 #include <drake/systems/framework/context.h>
 #include <drake/systems/rendering/pose_bundle.h>
+
+#include <maliput/common/maliput_copyable.h>
 
 #include "visualization/car_vis.h"
 
@@ -33,7 +34,7 @@ namespace delphyne {
 template <typename T>
 class PriusVis : public CarVis<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PriusVis)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(PriusVis)
 
   /// Defines the distance between the visual model's origin and the middle of
   /// the rear axle.

--- a/src/visualization/simple_prius_vis.h
+++ b/src/visualization/simple_prius_vis.h
@@ -13,13 +13,14 @@
 #include <string>
 #include <vector>
 
-#include <drake/common/drake_copyable.h>
 #include <drake/geometry/scene_graph.h>
 #include <drake/lcmt_viewer_link_data.hpp>
 #include <drake/multibody/plant/multibody_plant.h>
 #include <drake/multibody/tree/multibody_tree_indexes.h>
 #include <drake/systems/framework/context.h>
 #include <drake/systems/rendering/pose_bundle.h>
+
+#include <maliput/common/maliput_copyable.h>
 
 #include "visualization/car_vis.h"
 
@@ -39,7 +40,7 @@ namespace delphyne {
 template <typename T>
 class SimplePriusVis : public CarVis<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SimplePriusVis)
+  MALIPUT_NO_COPY_NO_MOVE_NO_ASSIGN(SimplePriusVis)
 
   /// Defines the distance between the visual model's origin and the middle of
   /// the rear axle.

--- a/test/regression/cpp/CMakeLists.txt
+++ b/test/regression/cpp/CMakeLists.txt
@@ -18,15 +18,20 @@ target_include_directories(
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/test/regression/cpp>
 )
 
+ament_target_dependencies(delphyne_test_utilities
+  "maliput"
+)
+
 target_link_libraries(delphyne_test_utilities
-  gtest
-  gtest_main
-  public_headers
   drake::drake
   drake_gen
+  gtest
+  gtest_main
   ignition-common3::ignition-common3
   ignition-msgs2::ignition-msgs2
   ignition-transport5::ignition-transport5
+  maliput::common
+  public_headers
 )
 
 ##############################################################################


### PR DESCRIPTION
> It matches with [maliput#246](https://github.com/ToyotaResearchInstitute/maliput/pull/246)

As the title says it **uses `maliput_copyable` instead of `drake_copyable`.**