### PR TITLE
Replaces drake::Matrix3<double> by maliput::math::Matrix3

### DIFF
--- a/test/regression/cpp/traffic_pose_selector_test.cc
+++ b/test/regression/cpp/traffic_pose_selector_test.cc
@@ -42,7 +42,6 @@ using drake::systems::rendering::PoseVector;
 using drake::AutoDiffXd;
 using drake::ExtractDoubleOrThrow;
 using drake::Isometry3;
-using drake::Matrix3;
 using drake::Translation3;
 using drake::Vector3;
 


### PR DESCRIPTION
Pairs with https://github.com/ToyotaResearchInstitute/maliput/pull/252