### PR TITLE
Adapt files to maliput::math::Matrix<N>.

### DIFF
--- a/src/systems/rail_follower.cc
+++ b/src/systems/rail_follower.cc
@@ -237,21 +237,17 @@ void RailFollower<T>::CalcVelocity(const drake::systems::Context<T>& context,
   //  - W is the world frame.
   //  - R is a rotation matrix.
 
-  const drake::Vector3<T> v_LC_L(lane_direction.with_s ? state.speed() : -state.speed(), 0 /* r_dot */, 0 /* h_dot */);
+  const maliput::math::Vector3 v_LC_L(lane_direction.with_s ? state.speed() : -state.speed(), 0 /* r_dot */,
+                                      0 /* h_dot */);
   const maliput::api::Rotation rotation =
       lane_direction.lane->GetOrientation(maliput::api::LanePosition(state.s(), params.r(), params.h()));
-  Eigen::Matrix<T, 3, 3> R_WL{};
-  const maliput::math::Matrix3 rotation_matrix_maliput{rotation.matrix()};
-  for (int i = 0; i < 3; i++) {
-    for (int j = 0; j < 3; j++) {
-      R_WL.row(i)[j] = rotation_matrix_maliput[i][j];
-    }
-  }
-  const drake::Vector3<T> v_WC_W = R_WL * v_LC_L;
+  const maliput::math::Matrix3 R_WL{rotation.matrix()};
+  const maliput::math::Vector3 v_WC_W{R_WL * v_LC_L};
 
   // TODO(liang.fok) Add support for non-zero rotational velocity. See #5751.
   const drake::Vector3<T> w(T(0), T(0), T(0));
-  frame_velocity->set_velocity(drake::multibody::SpatialVelocity<T>(w, v_WC_W));
+  frame_velocity->set_velocity(
+      drake::multibody::SpatialVelocity<T>(w, drake::Vector3<T>{v_WC_W.x(), v_WC_W.y(), v_WC_W.z()}));
 }
 
 template <typename T>


### PR DESCRIPTION
This PR matches with [maliput#253](https://github.com/ToyotaResearchInstitute/maliput/pull/253).

As the title says, A file was adapted to match with `maliput::math::Matrix<N>` implementation.