### PR TITLE
Fix algebraic loop caused by drake api changes.

### DIFF
--- a/src/systems/rail_follower.cc
+++ b/src/systems/rail_follower.cc
@@ -97,7 +97,8 @@ RailFollower<T>::RailFollower(const LaneDirection& initial_lane_direction,
   lane_state_output_port_index_ =
       this->DeclareAbstractOutputPort(LaneDirection(initial_lane_direction), &RailFollower::CalcLaneOutput).get_index();
   pose_output_port_index_ = this->DeclareVectorOutputPort(&RailFollower::CalcPose).get_index();
-  velocity_output_port_index_ = this->DeclareVectorOutputPort(&RailFollower::CalcVelocity).get_index();
+  velocity_output_port_index_ =
+      this->DeclareVectorOutputPort(&RailFollower::CalcVelocity, {this->xc_ticket()}).get_index();
   lane_direction_context_index_ =
       this->DeclareAbstractState(drake::AbstractValue::Make<LaneDirection>(initial_lane_direction));
   rail_follower_params_context_index_ = this->DeclareNumericParameter(initial_context_parameters);

--- a/test/regression/cpp/agent_simulation_builder_test.cc
+++ b/test/regression/cpp/agent_simulation_builder_test.cc
@@ -91,16 +91,14 @@ void CheckModelLinks(const ignition::msgs::Model_V& message) {
             model.link().end());
 }
 
-// TODO(delphyne#660) Tests are disabled to unblock development in the entire workspace.
-//
-// // Returns the x-position of the vehicle based on an ignition::msgs::Model_V.
-// // It also checks that the y-position of the vehicle is equal to the provided y
-// // value.
-// double GetXPosition(const ignition::msgs::Model_V& message, double y) {
-//   const ignition::msgs::Link& link = GetChassisFloorLink(message.models(0));
-//   EXPECT_DOUBLE_EQ(link.pose().position().y(), y);
-//   return link.pose().position().x();
-// }
+// Returns the x-position of the vehicle based on an ignition::msgs::Model_V.
+// It also checks that the y-position of the vehicle is equal to the provided y
+// value.
+double GetXPosition(const ignition::msgs::Model_V& message, double y) {
+  const ignition::msgs::Link& link = GetChassisFloorLink(message.models(0));
+  EXPECT_DOUBLE_EQ(link.pose().position().y(), y);
+  return link.pose().position().x();
+}
 
 }  // namespace
 
@@ -273,67 +271,65 @@ TEST_F(AgentSimulationTest, TestPriusSimpleCarInitialState) {
   EXPECT_EQ(state_message.angular_velocity().z(), 0.0);
 }
 
-// TODO(delphyne#660) Tests are disabled to unblock development in the entire workspace.
-//
-// TEST_F(AgentSimulationTest, TestMobilControlledSimpleCar) {
-//   // Set up a basic simulation with a MOBIL- and IDM-controlled SimpleCar.
-//   AgentSimulationBuilder builder;
-//   builder.SetTargetRealTimeRate(kRealtimeFactor);
-//   const maliput::api::RoadGeometry* road_geometry = builder.SetRoadGeometry(CreateDragway("TestDragway", 2));
-//   const maliput::api::Lane& first_lane = *(road_geometry->junction(0)->segment(0)->lane(0));
+TEST_F(AgentSimulationTest, TestMobilControlledSimpleCar) {
+  // Set up a basic simulation with a MOBIL- and IDM-controlled SimpleCar.
+  AgentSimulationBuilder builder;
+  builder.SetTargetRealTimeRate(kRealtimeFactor);
+  const maliput::api::RoadGeometry* road_geometry = builder.SetRoadGeometry(CreateDragway("TestDragway", 2));
+  const maliput::api::Lane& first_lane = *(road_geometry->junction(0)->segment(0)->lane(0));
 
-//   // Create one MOBIL car and two stopped cars arranged as follows:
-//   //
-//   // ---------------------------------------------------------------
-//   // ^  +r, +y                                          | Decoy 2 |
-//   // |    -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
-//   // +---->  +s, +x  | MOBIL Car |   | Decoy 1 |
-//   // ---------------------------------------------------------------
+  // Create one MOBIL car and two stopped cars arranged as follows:
+  //
+  // ---------------------------------------------------------------
+  // ^  +r, +y                                          | Decoy 2 |
+  // |    -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+  // +---->  +s, +x  | MOBIL Car |   | Decoy 1 |
+  // ---------------------------------------------------------------
 
-//   builder.AddAgent<MobilCarBlueprint>("MOBIL0",
-//                                       true,   // lane_direction,
-//                                       2.0,    // x
-//                                       -2.0,   // y
-//                                       0.0,    // heading
-//                                       10.0);  // velocity
+  builder.AddAgent<MobilCarBlueprint>("MOBIL0",
+                                      true,   // lane_direction,
+                                      2.0,    // x
+                                      -2.0,   // y
+                                      0.0,    // heading
+                                      10.0);  // velocity
 
-//   builder.AddAgent<RailCarBlueprint>("decoy1", first_lane,
-//                                      true,  // lane_direction,
-//                                      6.0,   // position (m)
-//                                      0.0,   // offset (m)
-//                                      0.0,   // speed (m)
-//                                      0.0);  // nominal_speed (m/s)
+  builder.AddAgent<RailCarBlueprint>("decoy1", first_lane,
+                                     true,  // lane_direction,
+                                     6.0,   // position (m)
+                                     0.0,   // offset (m)
+                                     0.0,   // speed (m)
+                                     0.0);  // nominal_speed (m/s)
 
-//   builder.AddAgent<RailCarBlueprint>("decoy2", first_lane,
-//                                      true,  // lane_direction,
-//                                      20.0,  // position (m)
-//                                      0.0,   // offset (m)
-//                                      0.0,   // speed (m/s)
-//                                      0.0);  // nominal_speed (m/s)
+  builder.AddAgent<RailCarBlueprint>("decoy2", first_lane,
+                                     true,  // lane_direction,
+                                     20.0,  // position (m)
+                                     0.0,   // offset (m)
+                                     0.0,   // speed (m/s)
+                                     0.0);  // nominal_speed (m/s)
 
-//   std::unique_ptr<AgentSimulation> simulation = builder.Build();
+  std::unique_ptr<AgentSimulation> simulation = builder.Build();
 
-//   // Setup an ignition transport topic monitor to listen to
-//   // ignition::msgs::Model_V messages being published to
-//   // the visualizer.
-//   const std::string kDrawTopicName{"visualizer/scene_update"};
-//   test::IgnMonitor<ignition::msgs::Model_V> ign_monitor(kDrawTopicName);
+  // Setup an ignition transport topic monitor to listen to
+  // ignition::msgs::Model_V messages being published to
+  // the visualizer.
+  const std::string kDrawTopicName{"visualizer/scene_update"};
+  test::IgnMonitor<ignition::msgs::Model_V> ign_monitor(kDrawTopicName);
 
-//   // Advances the simulation to allow the MaliputRailcar to begin
-//   // accelerating.
-//   simulation->StepBy(kLargeTimeStep);
+  // Advances the simulation to allow the MaliputRailcar to begin
+  // accelerating.
+  simulation->StepBy(kLargeTimeStep);
 
-//   // Ensures that at least one draw message has arrived.
-//   const int kDrawMessagesCount{1};
-//   EXPECT_TRUE(ign_monitor.wait_until(kDrawMessagesCount, kTimeoutMs));
+  // Ensures that at least one draw message has arrived.
+  const int kDrawMessagesCount{1};
+  EXPECT_TRUE(ign_monitor.wait_until(kDrawMessagesCount, kTimeoutMs));
 
-//   const ignition::msgs::Model_V draw_message = ign_monitor.get_last_message();
-//   EXPECT_EQ(GetLinkCount(draw_message), 3 * GetPriusLinkCount());
+  const ignition::msgs::Model_V draw_message = ign_monitor.get_last_message();
+  EXPECT_EQ(GetLinkCount(draw_message), 3 * GetPriusLinkCount());
 
-//   // Expect the SimpleCar to start steering to the left; y value increases.
-//   const ignition::msgs::Link& link = GetChassisFloorLink(draw_message.models(0));
-//   EXPECT_GE(link.pose().position().y(), -2.);
-// }
+  // Expect the SimpleCar to start steering to the left; y value increases.
+  const ignition::msgs::Link& link = GetChassisFloorLink(draw_message.models(0));
+  EXPECT_GE(link.pose().position().y(), -2.);
+}
 
 TEST_F(AgentSimulationTest, TestTrajectoryAgent) {
   // Tolerance is rather large as the trajectory agent
@@ -420,44 +416,42 @@ TEST_F(AgentSimulationTest, TestBadRailcars) {
       "geometry as that used by the simulation");
 }
 
-// TODO(delphyne#660) Tests are disabled to unblock development in the entire workspace.
-//
 // Covers railcar behavior.
-// TEST_F(AgentSimulationTest, TestMaliputRailcar) {
-//   AgentSimulationBuilder builder;
-//   builder.SetTargetRealTimeRate(kRealtimeFactor);
-//   const maliput::api::RoadGeometry* road_geometry = builder.SetRoadGeometry(CreateDragway("TestDragway", 1));
-//   const maliput::api::Lane& lane = *(road_geometry->junction(0)->segment(0)->lane(0));
-//   const double k_offset{0.5};
-//   builder.AddAgent<RailCarBlueprint>("railcar", lane,
-//                                      true,      // lane_direction,
-//                                      0.0,       // position
-//                                      k_offset,  // offset
-//                                      0.0,       // speed
-//                                      0.0);      // nominal_speed
-//   std::unique_ptr<AgentSimulation> simulation = builder.Build();
+TEST_F(AgentSimulationTest, TestMaliputRailcar) {
+  AgentSimulationBuilder builder;
+  builder.SetTargetRealTimeRate(kRealtimeFactor);
+  const maliput::api::RoadGeometry* road_geometry = builder.SetRoadGeometry(CreateDragway("TestDragway", 1));
+  const maliput::api::Lane& lane = *(road_geometry->junction(0)->segment(0)->lane(0));
+  const double k_offset{0.5};
+  builder.AddAgent<RailCarBlueprint>("railcar", lane,
+                                     true,      // lane_direction,
+                                     0.0,       // position
+                                     k_offset,  // offset
+                                     0.0,       // speed
+                                     0.0);      // nominal_speed
+  std::unique_ptr<AgentSimulation> simulation = builder.Build();
 
-//   // Setup an ignition transport topic monitor to listen to
-//   // ignition::msgs::Model_V messages being published to
-//   // the visualizer.
-//   const std::string kDrawTopicName{"visualizer/scene_update"};
-//   test::IgnMonitor<ignition::msgs::Model_V> ign_monitor(kDrawTopicName);
+  // Setup an ignition transport topic monitor to listen to
+  // ignition::msgs::Model_V messages being published to
+  // the visualizer.
+  const std::string kDrawTopicName{"visualizer/scene_update"};
+  test::IgnMonitor<ignition::msgs::Model_V> ign_monitor(kDrawTopicName);
 
-//   simulation->StepBy(kLargeTimeStep);
+  simulation->StepBy(kLargeTimeStep);
 
-//   // Ensures that at least one draw message has arrived.
-//   const int kDrawMessagesCount{1};
-//   EXPECT_TRUE(ign_monitor.wait_until(kDrawMessagesCount, kTimeoutMs));
+  // Ensures that at least one draw message has arrived.
+  const int kDrawMessagesCount{1};
+  EXPECT_TRUE(ign_monitor.wait_until(kDrawMessagesCount, kTimeoutMs));
 
-//   // Retrieves last draw message.
-//   const ignition::msgs::Model_V draw_message = ign_monitor.get_last_message();
+  // Retrieves last draw message.
+  const ignition::msgs::Model_V draw_message = ign_monitor.get_last_message();
 
-//   // Verifies the acceleration is zero.
-//   CheckModelLinks(draw_message);
+  // Verifies the acceleration is zero.
+  CheckModelLinks(draw_message);
 
-//   const double kPoseXTolerance{1e-8};
-//   EXPECT_NEAR(GetXPosition(draw_message, k_offset), 0., kPoseXTolerance);
-// }
+  const double kPoseXTolerance{1e-8};
+  EXPECT_NEAR(GetXPosition(draw_message, k_offset), 0., kPoseXTolerance);
+}
 
 // Verifies that CarVisApplicator, PoseBundleToDrawMessage, and
 // LcmPublisherSystem are instantiated in Simulation's Diagram and
@@ -501,98 +495,96 @@ TEST_F(AgentSimulationTest, TestLcmOutput) {
   EXPECT_EQ(GetLinkCount(draw_message), 2 * GetPriusLinkCount());
 }
 
-// TODO(delphyne#660) Tests are disabled to unblock development in the entire workspace.
-//
 // Verifies that exceptions are thrown if a vehicle with a non-unique name is
 // added to the simulation.
-// TEST_F(AgentSimulationTest, TestDuplicateVehicleNameException) {
-//   AgentSimulationBuilder builder;
+TEST_F(AgentSimulationTest, TestDuplicateVehicleNameException) {
+  AgentSimulationBuilder builder;
 
-//   const maliput::api::RoadGeometry* road_geometry = builder.SetRoadGeometry(CreateDragway("TestDragway", 1));
+  const maliput::api::RoadGeometry* road_geometry = builder.SetRoadGeometry(CreateDragway("TestDragway", 1));
 
-//   EXPECT_NO_THROW(builder.AddAgent<SimpleCarBlueprint>("Model1", 0.0, 0.0, 0.0, 0.0));
-//   EXPECT_RUNTIME_THROW(builder.AddAgent<SimpleCarBlueprint>("Model1", 0.0, 0.0, 0.0, 0.0),
-//                        "An agent named \"Model1\" already exists.");
+  EXPECT_NO_THROW(builder.AddAgent<SimpleCarBlueprint>("Model1", 0.0, 0.0, 0.0, 0.0));
+  EXPECT_RUNTIME_THROW(builder.AddAgent<SimpleCarBlueprint>("Model1", 0.0, 0.0, 0.0, 0.0),
+                       "An agent named \"Model1\" already exists.");
 
-//   const maliput::api::Lane& lane = *(road_geometry->junction(0)->segment(0)->lane(0));
+  const maliput::api::Lane& lane = *(road_geometry->junction(0)->segment(0)->lane(0));
 
-//   EXPECT_NO_THROW(builder.AddAgent<RailCarBlueprint>("FOO", lane,
-//                                                      true,   // lane_direction,
-//                                                      0.0,    // position
-//                                                      0.0,    // offset
-//                                                      0.0,    // speed
-//                                                      5.0));  // nominal_speed
+  EXPECT_NO_THROW(builder.AddAgent<RailCarBlueprint>("FOO", lane,
+                                                     true,   // lane_direction,
+                                                     0.0,    // position
+                                                     0.0,    // offset
+                                                     0.0,    // speed
+                                                     5.0));  // nominal_speed
 
-//   EXPECT_NO_THROW(builder.AddAgent<RailCarBlueprint>("alice", lane,
-//                                                      true,   // lane_direction,
-//                                                      0.0,    // position
-//                                                      0.0,    // offset
-//                                                      0.0,    // speed
-//                                                      5.0));  // nominal_speed
+  EXPECT_NO_THROW(builder.AddAgent<RailCarBlueprint>("alice", lane,
+                                                     true,   // lane_direction,
+                                                     0.0,    // position
+                                                     0.0,    // offset
+                                                     0.0,    // speed
+                                                     5.0));  // nominal_speed
 
-//   EXPECT_RUNTIME_THROW(builder.AddAgent<RailCarBlueprint>("alice", lane,
-//                                                           true,  // lane_direction,
-//                                                           0.0,   // position
-//                                                           0.0,   // offset
-//                                                           0.0,   // speed
-//                                                           5.0),  // nominal_speed
-//                        "An agent named \"alice\" already exists.");
-// }
+  EXPECT_RUNTIME_THROW(builder.AddAgent<RailCarBlueprint>("alice", lane,
+                                                          true,  // lane_direction,
+                                                          0.0,   // position
+                                                          0.0,   // offset
+                                                          0.0,   // speed
+                                                          5.0),  // nominal_speed
+                       "An agent named \"alice\" already exists.");
+}
 
-// TODO(delphyne#660) Tests are disabled to unblock development in the entire workspace.
-//
 // Verifies that the velocity outputs of the rail cars are connected to
 // the PoseAggregator, which prevents a regression of #5894.
-// TEST_F(AgentSimulationTest, TestRailcarVelocityOutput) {
-//   AgentSimulationBuilder builder;
+TEST_F(AgentSimulationTest, TestRailcarVelocityOutput) {
+  AgentSimulationBuilder builder;
 
-//   const maliput::api::RoadGeometry* road_geometry =
-//       builder.SetRoadGeometry(std::make_unique<const maliput::dragway::RoadGeometry>(
-//           maliput::api::RoadGeometryId("TestDragway"), 1 /* num lanes */, 100 /* length */, 4 /* lane width */,
-//           1 /* shoulder width */, 5 /* maximum_height */, std::numeric_limits<double>::epsilon() /* linear_tolerance
-//           */, std::numeric_limits<double>::epsilon() /* angular_tolerance */));
+  const maliput::api::RoadGeometry* road_geometry =
+      builder.SetRoadGeometry(std::make_unique<const maliput::dragway::RoadGeometry>(
+          maliput::api::RoadGeometryId("TestDragway"), 1 /* num lanes */, 100 /* length */, 4 /* lane width */,
+          1 /* shoulder width */, 5 /* maximum_height */, std::numeric_limits<double>::epsilon() /* linear_tolerance
+                                                                                                  */
+          ,
+          std::numeric_limits<double>::epsilon() /* angular_tolerance */));
 
-//   const maliput::api::Lane& lane = *(road_geometry->junction(0)->segment(0)->lane(0));
+  const maliput::api::Lane& lane = *(road_geometry->junction(0)->segment(0)->lane(0));
 
-//   const double kR{0.5};
+  const double kR{0.5};
 
-//   builder.AddAgent<RailCarBlueprint>("alice", lane,
-//                                      true,  // lane_direction,
-//                                      5.0,   // position
-//                                      kR,    // offset
-//                                      1.0,   // speed
-//                                      5.0);  // nominal_speed
+  builder.AddAgent<RailCarBlueprint>("alice", lane,
+                                     true,  // lane_direction,
+                                     5.0,   // position
+                                     kR,    // offset
+                                     1.0,   // speed
+                                     5.0);  // nominal_speed
 
-//   builder.AddAgent<RailCarBlueprint>("bob", lane,
-//                                      true,  // lane_direction,
-//                                      0.0,   // position
-//                                      kR,    // offset
-//                                      0.0,   // speed
-//                                      0.0);  // nominal_speed
+  builder.AddAgent<RailCarBlueprint>("bob", lane,
+                                     true,  // lane_direction,
+                                     0.0,   // position
+                                     kR,    // offset
+                                     0.0,   // speed
+                                     0.0);  // nominal_speed
 
-//   std::unique_ptr<AgentSimulation> simulation = builder.Build();
+  std::unique_ptr<AgentSimulation> simulation = builder.Build();
 
-//   // Advances the simulation to allow Alice to move at fixed
-//   // speed and Bob to not move.
-//   simulation->StepBy(kLargeTimeStep);
+  // Advances the simulation to allow Alice to move at fixed
+  // speed and Bob to not move.
+  simulation->StepBy(kLargeTimeStep);
 
-//   const int kAliceIndex{0};
-//   const int kBobIndex{1};
+  const int kAliceIndex{0};
+  const int kBobIndex{1};
 
-//   // Verifies that the velocity within the PoseAggregator's PoseBundle output
-//   // is non-zero.
-//   const drake::systems::rendering::PoseBundle<double> poses = simulation->GetCurrentPoses();
-//   ASSERT_EQ(poses.get_num_poses(), 2);
+  // Verifies that the velocity within the PoseAggregator's PoseBundle output
+  // is non-zero.
+  const drake::systems::rendering::PoseBundle<double> poses = simulation->GetCurrentPoses();
+  ASSERT_EQ(poses.get_num_poses(), 2);
 
-//   ASSERT_EQ(poses.get_model_instance_id(kAliceIndex), 0);
-//   ASSERT_EQ(poses.get_model_instance_id(kBobIndex), 1);
-//   const RailCar& alice = simulation->GetAgentByName<RailCar>("alice");
-//   ASSERT_EQ(poses.get_name(kAliceIndex), alice.name());
-//   const RailCar& bob = simulation->GetAgentByName<RailCar>("bob");
-//   ASSERT_EQ(poses.get_name(kBobIndex), bob.name());
-//   EXPECT_FALSE(poses.get_velocity(kAliceIndex).get_value().isZero());
-//   EXPECT_TRUE(poses.get_velocity(kBobIndex).get_value().isZero());
-// }
+  ASSERT_EQ(poses.get_model_instance_id(kAliceIndex), 0);
+  ASSERT_EQ(poses.get_model_instance_id(kBobIndex), 1);
+  const RailCar& alice = simulation->GetAgentByName<RailCar>("alice");
+  ASSERT_EQ(poses.get_name(kAliceIndex), alice.name());
+  const RailCar& bob = simulation->GetAgentByName<RailCar>("bob");
+  ASSERT_EQ(poses.get_name(kBobIndex), bob.name());
+  EXPECT_FALSE(poses.get_velocity(kAliceIndex).get_value().isZero());
+  EXPECT_TRUE(poses.get_velocity(kBobIndex).get_value().isZero());
+}
 
 // Tests Build logic
 TEST_F(AgentSimulationTest, TestBuild) {


### PR DESCRIPTION
>Solves #660 

When we updated `Drake` a small modification was added when declaring systems and its output and inputs vectors.

Tests were failing because an algebraic loop(Input was direct feedthrough to the output) was found.

>C++ exception with description "Reported algebraic loop detected in DiagramBuilder:
5:   InputPort[0] (u0) of System ::decoy1_system (RailFollower<double>) is direct-feedthrough to
5:   OutputPort[4] (y4) of System ::decoy1_system (RailFollower<double>) is connected to
5:   InputPort[0] (u0) of System ::delphyne/SpeedSystem@00005654fa004a00 (SpeedSystem<double>) is direct-feedthrough to
5:   OutputPort[0] (y0) of System ::delphyne/SpeedSystem@00005654fa004a00 (SpeedSystem<double>) is connected to
5:   InputPort[0] (u0) of System ::decoy1_system (RailFollower<double>)

Apparently the Delphyne system compound by `SpeedSystem` and `RailFollower` was failing because of this.

In Drake page, I could find information about this:
Extract [from Drake page](https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_leaf_system.html#a83479e1867e83638b90266c1aed0b6a3):
>By default, LeafSystem assumes there is direct feedthrough of values from every input to every output. This is a conservative assumption that ensures we detect and can prevent the formation of algebraic loops (implicit computations) in system Diagrams.

To solve this they recommend:
>When declaring output ports (e.g., DeclareVectorOutputPort()), provide a non-default value to the prerequisites_of_calc argument. When the prerequisites_of_calc implies no dependency on some inputs, the framework automatically infers that the output is not direct-feedthrough for those inputs. 

So adding a correct `drake::SystemBase::DependencyTicket` to the output port declaration solves the problem we had.
