### PR TITLE
Remove pybind11-dev from package.xml.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -45,7 +45,6 @@
   <depend>multilane</depend>
   <depend>maliput-utilities</depend>
   <depend>dragway</depend>
-  <depend>pybind11-dev</depend>
 
   <build_export_depend>drake_vendor</build_export_depend>
   <build_export_depend>ignition-common3</build_export_depend>


### PR DESCRIPTION
Removes the dependency on `pybind11-dev` in the `package.xml` file.

This is making `rosdep` to install one version of `pybind11` that is not being used.