### PR TITLE
Fix deprecation warnings for drake@2020-01-09

### DIFF
--- a/src/backend/agent_simulation_builder.cc
+++ b/src/backend/agent_simulation_builder.cc
@@ -312,9 +312,9 @@ std::unique_ptr<AgentSimulationBase<T>> AgentSimulationBaseBuilder<T>::Build() {
   auto simulator = std::make_unique<drake::systems::Simulator<T>>(*diagram);
   simulator->set_target_realtime_rate(GetTargetRealTimeRate());
   drake::systems::Context<T>& context = simulator->get_mutable_context();
-  drake::systems::RungeKutta2Integrator<T>* integrator =
-      simulator->template reset_integrator<RungeKutta2Integrator<T>>(*diagram, GetMaxStepSize(), &context);
-  integrator->set_fixed_step_mode(UsesFixedStepMode());
+  drake::systems::RungeKutta2Integrator<T>& integrator =
+      simulator->template reset_integrator<RungeKutta2Integrator<T>>(GetMaxStepSize());
+  integrator.set_fixed_step_mode(UsesFixedStepMode());
   simulator->Initialize();
 
   // Injects simulation context references into agents.

--- a/src/backend/geometry_utilities.cc
+++ b/src/backend/geometry_utilities.cc
@@ -16,7 +16,7 @@ namespace delphyne {
 drake::lcmt_viewer_load_robot BuildLoadMessageForRoad(const maliput::api::RoadGeometry& road_geometry,
                                                       const maliput::utility::ObjFeatures& features) {
   drake::geometry::SceneGraph<double> scene_graph;
-  drake::multibody::MultibodyPlant<double> plant;
+  drake::multibody::MultibodyPlant<double> plant(0.0);
   plant.RegisterAsSourceForSceneGraph(&scene_graph);
   std::string filename = road_geometry.id().string();
   std::transform(filename.begin(), filename.end(), filename.begin(), [](char ch) { return ch == ' ' ? '_' : ch; });

--- a/src/visualization/prius_vis.h
+++ b/src/visualization/prius_vis.h
@@ -47,7 +47,7 @@ class PriusVis : public CarVis<T> {
 
  private:
   drake::geometry::SceneGraph<T> scene_graph_{};
-  drake::multibody::MultibodyPlant<T> plant_{};
+  drake::multibody::MultibodyPlant<T> plant_{0.0};
   drake::multibody::ModelInstanceIndex prius_index_{};
   std::unique_ptr<drake::systems::Context<T>> plant_context_{nullptr};
   std::vector<drake::lcmt_viewer_link_data> vis_elements_{};

--- a/src/visualization/simple_prius_vis.h
+++ b/src/visualization/simple_prius_vis.h
@@ -53,7 +53,7 @@ class SimplePriusVis : public CarVis<T> {
 
  private:
   drake::geometry::SceneGraph<T> scene_graph_{};
-  drake::multibody::MultibodyPlant<T> plant_{};
+  drake::multibody::MultibodyPlant<T> plant_{0.0};
   drake::multibody::ModelInstanceIndex prius_index_{};
   std::unique_ptr<drake::systems::Context<T>> plant_context_{nullptr};
   std::vector<drake::lcmt_viewer_link_data> vis_elements_{};


### PR DESCRIPTION
Part of #682. Fixes deprecation warnings caused by updating drake version in https://github.com/ToyotaResearchInstitute/drake-vendor/pull/12. 