### PR TITLE
Fix drake 0.16.1 build failure (test with 0.16.1)

### DIFF
--- a/src/backend/ign_subscriber_system.h
+++ b/src/backend/ign_subscriber_system.h
@@ -38,6 +38,8 @@ class IgnSubscriberSystem : public drake::systems::LeafSystem<double> {
                               [this](const drake::systems::Context<double>& context, drake::AbstractValue* out) {
                                 this->IgnSubscriberSystem::CalcIgnMessage(context, out);
                               });
+    DeclareAbstractState(std::make_unique<drake::Value<IGN_TYPE>>(IGN_TYPE{}));
+    DeclareAbstractState(drake::AbstractValue::Make<int>(0));
 
     if (!node_.Subscribe(topic_name_, &IgnSubscriberSystem<IGN_TYPE>::HandleMessage, this)) {
       ignerr << "Error subscribing to topic: " << topic_name_ << "\n Ignition Subscriber will not work" << std::endl;
@@ -48,13 +50,6 @@ class IgnSubscriberSystem : public drake::systems::LeafSystem<double> {
 
   std::unique_ptr<drake::AbstractValue> AllocateDefaultAbstractValue() const {
     return std::make_unique<drake::Value<IGN_TYPE>>(IGN_TYPE{});
-  }
-
-  std::unique_ptr<drake::systems::AbstractValues> AllocateAbstractState() const override {
-    std::vector<std::unique_ptr<drake::AbstractValue>> abstract_values(kTotalStateValues);
-    abstract_values[kStateIndexMessage] = AllocateDefaultAbstractValue();
-    abstract_values[kStateIndexMessageCount] = drake::AbstractValue::Make<int>(0);
-    return std::make_unique<drake::systems::AbstractValues>(std::move(abstract_values));
   }
 
   void SetDefaultState(const drake::systems::Context<double>&, drake::systems::State<double>* state) const override {


### PR DESCRIPTION
Use DeclareAbstractState instead of overriding AllocateAbstractState (due to https://github.com/RobotLocomotion/drake/pull/12792).

Part of https://github.com/ToyotaResearchInstitute/delphyne/issues/682. This uses the same branch name as https://github.com/ToyotaResearchInstitute/drake-vendor/pull/13, so it will test against drake 0.16.1.