### PR TITLE
Fix drake 0.16.1 build failure (test with current drake-vendor)

### DIFF
--- a/src/backend/ign_subscriber_system.h
+++ b/src/backend/ign_subscriber_system.h
@@ -38,6 +38,8 @@ class IgnSubscriberSystem : public drake::systems::LeafSystem<double> {
                               [this](const drake::systems::Context<double>& context, drake::AbstractValue* out) {
                                 this->IgnSubscriberSystem::CalcIgnMessage(context, out);
                               });
+    DeclareAbstractState(std::make_unique<drake::Value<IGN_TYPE>>(IGN_TYPE{}));
+    DeclareAbstractState(drake::AbstractValue::Make<int>(0));
 
     if (!node_.Subscribe(topic_name_, &IgnSubscriberSystem<IGN_TYPE>::HandleMessage, this)) {
       ignerr << "Error subscribing to topic: " << topic_name_ << "\n Ignition Subscriber will not work" << std::endl;
@@ -48,13 +50,6 @@ class IgnSubscriberSystem : public drake::systems::LeafSystem<double> {
 
   std::unique_ptr<drake::AbstractValue> AllocateDefaultAbstractValue() const {
     return std::make_unique<drake::Value<IGN_TYPE>>(IGN_TYPE{});
-  }
-
-  std::unique_ptr<drake::systems::AbstractValues> AllocateAbstractState() const override {
-    std::vector<std::unique_ptr<drake::AbstractValue>> abstract_values(kTotalStateValues);
-    abstract_values[kStateIndexMessage] = AllocateDefaultAbstractValue();
-    abstract_values[kStateIndexMessageCount] = drake::AbstractValue::Make<int>(0);
-    return std::make_unique<drake::systems::AbstractValues>(std::move(abstract_values));
   }
 
   void SetDefaultState(const drake::systems::Context<double>&, drake::systems::State<double>* state) const override {


### PR DESCRIPTION
Use DeclareAbstractState instead of overriding AllocateAbstractState (due to RobotLocomotion/drake#12792).

Part of #682. This **does not** use the same branch name as ToyotaResearchInstitute/drake-vendor#13, so it will test against the current version of drake-vendor that points to https://github.com/RobotLocomotion/drake/commit/7281e22106e190ea0a28ce88140a5c4ba437c1d6.