### PR TITLE
Fix issue when creating a temp directory.

### DIFF
--- a/test/regression/cpp/test_utilities/helpers.cc
+++ b/test/regression/cpp/test_utilities/helpers.cc
@@ -546,6 +546,7 @@ bool AssertLinkNumberEquivalence(const drake::lcmt_viewer_draw& lcm_msg, const i
 std::string MakeTemporaryDirectory(const std::string& template_path) {
   char template_array[template_path.length() + 1];
   template_path.copy(template_array, template_path.length());
+  template_array[template_path.length()] = '\0';
   return mkdtemp(template_array);
 }
 


### PR DESCRIPTION
The following function from `src/delphyne/test/regression/cpp/test_utilities/helpers.cc` wasn't working properly when compiling with `clang`.
```
std::string MakeTemporaryDirectory(const std::string& template_path) {
  char template_array[template_path.length() + 1];
  template_path.copy(template_array, template_path.length());
  return mkdtemp(template_array);
}
```

 Apparently a copy from a string into a char array wasn't properly made. 
They forgot to add a `\0` at the end of the array after copying it from a string.

Adding:
`template_array[template_path.length()] = '\0';`
solves the problem.

`gcc` sorted that problem somehow (given that it's been working well) but `clang` does not.