### PR TITLE
Static Analyzer: Adds exclusion file.

### DIFF
--- a/tools/scan_build.supp
+++ b/tools/scan_build.supp
@@ -1,5 +1,5 @@
 /opt/drake/include/drake
-/usr/include/eigen3/Eigen
+/usr/include/eigen3
 /usr/include/google/protobuf
 build/delphyne/include/delphyne/protobuf
 src/delphyne/test/libgtest


### PR DESCRIPTION
> One step of [dsim-repos-index#64](https://github.com/ToyotaResearchInstitute/dsim-repos-index/issues/64)

The Static Analyzer found several bugs:
- 54 bugs were found in third-party-libraries(`gtest`, `drake`, `protobuf`, `eigen`)
   Directories were excluded to avoid those warnings.

-------------------
To use the static analyzer:
```
scan-build-8 --status-bugs --use-cc=clang --use-c++=clang++ --exclude opt/drake/include/drake --exclude /usr/include/eigen3/Eigen --exclude usr/include/google/protobuf --exclude build/delphyne/include/delphyne/protobuf --exclude src/delphyne/test/libgtest colcon build --packages-select delphyne  --cmake-args ' -DCMAKE_LINKER=usr/bin/llvm-ld'
```


