### PR TITLE
Disables a test when running sanitizers.

### DIFF
--- a/test/regression/cpp/CMakeLists.txt
+++ b/test/regression/cpp/CMakeLists.txt
@@ -84,9 +84,9 @@ set(SOURCES
 
 delphyne_build_tests(${SOURCES})
 
-# TODO(francocipollone): Improve test suppression.
+# TODO(#694): Improve test suppression.
 if (NOT ${SANITIZERS})
-  # This test accuses a stack overflow in CI when running asan
+  # This test causes a stack overflow in CI when running asan
   # occasioned during a EXPECT_DEATH statement.
   delphyne_build_tests(simulation_run_stats_test.cc)
 endif()


### PR DESCRIPTION
> One step of [dsim-repos-index#64](https://github.com/ToyotaResearchInstitute/dsim-repos-index/issues/64)

When running `asan` `  simulation_run_stats_test.cc` leads to a `stack overflow error` caused by the gtest macro `EXPECT_DEATH` in combination with `asan`. 
The test was disabled when running sanitizers.