### PR TITLE
Matches with the migration of malidrive::common.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(malidrive REQUIRED)
 find_package(maliput REQUIRED)
 find_package(maliput_dragway REQUIRED)
 find_package(maliput_multilane REQUIRED)
+find_package(maliput_malidrive REQUIRED)
 
 find_package(ignition-common3 REQUIRED COMPONENTS graphics)
 find_package(ignition-math6 REQUIRED)


### PR DESCRIPTION
Related to https://github.com/ToyotaResearchInstitute/malidrive/issues/643

Matches with https://github.com/ToyotaResearchInstitute/malidrive/pull/670