### PR TITLE
Reference malidrive libraries using the namespace notation.

### DIFF
--- a/src/roads/CMakeLists.txt
+++ b/src/roads/CMakeLists.txt
@@ -34,8 +34,8 @@ ament_target_dependencies(roads_utilities
 target_link_libraries(
   roads_utilities
     drake::drake
-    malidrive::malidrive_builder
-    malidrive::malidrive_loader
+    malidrive::builder
+    malidrive::loader
     maliput::api
     maliput_dragway::maliput_dragway
     maliput_multilane::maliput_multilane


### PR DESCRIPTION
Pairs changes introduced in https://github.com/ToyotaResearchInstitute/malidrive/pull/725