### PR TITLE
Pairs with changes in target name in maliput_multilane.

### DIFF
--- a/test/regression/cpp/CMakeLists.txt
+++ b/test/regression/cpp/CMakeLists.txt
@@ -25,7 +25,7 @@ ament_target_dependencies(delphyne_test_utilities
 target_link_libraries(delphyne_test_utilities
   public_headers
   drake::drake
-  maliput_multilane::maliput_multilane_test_utilities
+  maliput_multilane::test_utilities
   drake_gen
   ignition-common3::ignition-common3
   ignition-msgs2::ignition-msgs2


### PR DESCRIPTION
Relates to https://github.com/ToyotaResearchInstitute/dsim-repos-index/issues/146

See https://github.com/ToyotaResearchInstitute/maliput-multilane/pull/31 for reference.

It updates the dependency on `maliput-multilane::test_utilities`