### PR TITLE
Accommodate versioned installations of drake.

### DIFF
--- a/tools/scan_build.supp
+++ b/tools/scan_build.supp
@@ -1,4 +1,4 @@
-/opt/drake/include/drake
+/opt/drake
 /usr/include/eigen3
 /usr/include/google/protobuf
 build/delphyne/include/delphyne/protobuf


### PR DESCRIPTION
These will now be typically installed in /opt/drake/<version>.

Needed for https://github.com/ToyotaResearchInstitute/drake-vendor/pull/23, but not the other way around, so probably can go in directly.