### PR TITLE
Document the expected types of /get_scene service

### DIFF
--- a/src/backend/simulation_runner.h
+++ b/src/backend/simulation_runner.h
@@ -326,6 +326,10 @@ class SimulationRunner {
   static constexpr char const* kClockTopic = "/clock";
 
   // @brief The service used when receiving a scene request.
+  // This service expects an ignition::msgs::SceneRequest as the request type
+  // and replies with an ignition::msgs::Boolean type.
+  //
+  // @see OnSceneRequest
   static constexpr char const* kSceneRequestServiceName = "/get_scene";
 
  private:
@@ -375,7 +379,8 @@ class SimulationRunner {
 
   // @brief Service used to receive scene request messages.
   //
-  // @param[in] request The request.
+  // @param[in] request The request, which contains the name of a service that
+  // expects an ignition::msgs::Scene message request with no reply type.
   //
   // @param[out] response The response (unused).
   // @return The result of the service.


### PR DESCRIPTION
The `/get_scene` service expects an `ignition::msgs::SceneRequest` message as the request type and replies with `ignition::msgs::Boolean`. The SceneRequest message it self contains the name of a service that expects an `ignition::msgs::Scene` message as the request with no reply type (see [delphyne_gui/visualizer/render_widget.cc](https://github.com/ToyotaResearchInstitute/delphyne-gui/blob/1730bd146af9c6d9595fc5b0d8408e0806d4f61f/delphyne_gui/visualizer/render_widget.cc#L118-L134)).

I think the intermediate service could be avoided if the `/get_scene` service had no request type and replied with a `Scene` (which is what the [ign-gui2 Scene3D plugin](https://github.com/ignitionrobotics/ign-gui/blob/ignition-gui2_2.3.3/src/plugins/scene3d/Scene3D.cc#L303-L408) expects).