### PR TITLE
Remove culling property

### DIFF
--- a/src/translations/lcm_viewer_draw_to_ign_model_v.cc
+++ b/src/translations/lcm_viewer_draw_to_ign_model_v.cc
@@ -3,7 +3,6 @@
 #include "translations/lcm_viewer_draw_to_ign_model_v.h"
 
 #include <map>
-#include <sstream>
 
 #include <maliput/common/maliput_unused.h>
 

--- a/src/translations/lcm_viewer_load_robot_to_ign_model_v.cc
+++ b/src/translations/lcm_viewer_load_robot_to_ign_model_v.cc
@@ -3,7 +3,6 @@
 #include "translations/lcm_viewer_load_robot_to_ign_model_v.h"
 
 #include <map>
-#include <sstream>
 #include <vector>
 
 // public headers


### PR DESCRIPTION
Part of https://github.com/ToyotaResearchInstitute/delphyne-gui/pull/356

Goes on top of #750 

It removes the `?culling=off` parameter to the mesh URI of a RoadNetwork. It is not used by the current `RenderWidget` class and it prevents the new `Scene3D` plugin to load the mesh URI (it does not support encoded parameters).


Should be reviewed from 844ea15 on.

Goes hand in hand with https://github.com/ToyotaResearchInstitute/delphyne-gui/pull/356