### PR TITLE
Fix body joint name in prius sdf models

### DIFF
--- a/media/prius/prius_with_lidar.sdf
+++ b/media/prius/prius_with_lidar.sdf
@@ -509,7 +509,7 @@
         </limit>
       </axis>
     </joint>
-    <joint name="body" type="fixed">
+    <joint name="body_joint" type="fixed">
       <parent>chassis_floor</parent>
       <child>body</child>
       <pose>0 0 0 0 0 0</pose>

--- a/media/prius/simple_prius.sdf
+++ b/media/prius/simple_prius.sdf
@@ -245,7 +245,7 @@ https://github.com/RobotLocomotion/drake/blob/master/automotive/models/prius/pri
         <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
     </joint>
-    <joint name="body" type="fixed">
+    <joint name="body_joint" type="fixed">
       <parent>chassis_floor</parent>
       <child>body</child>
       <pose>0 0 0 0 0 0</pose>


### PR DESCRIPTION
The prius models contain a link and joint both named "body",
which causes a console warning in SDFormat 1.7+, which is now
used by drake. This renames the joint to "body_joint" and
fixes some console warnings in delphyne demos.