### PR TITLE
Add directional light to scene_system

### DIFF
--- a/src/backend/scene_system.cc
+++ b/src/backend/scene_system.cc
@@ -13,6 +13,10 @@ namespace delphyne {
 template <class T>
 using ProtobufIterator = google::protobuf::internal::RepeatedPtrIterator<T>;
 
+const ignition::math::Color SceneSystem::kLightColor{0.9, 0.9, 0.9};
+
+const ignition::math::Vector3d SceneSystem::kLightDirection{-0.5, -0.5, -1};
+
 SceneSystem::SceneSystem() {
   geometry_models_input_port_index_ =
       DeclareAbstractInputPort(drake::systems::kUseDefaultName, drake::Value<ignition::msgs::Model_V>()).get_index();

--- a/src/backend/scene_system.h
+++ b/src/backend/scene_system.h
@@ -41,19 +41,19 @@ class SceneSystem : public drake::systems::LeafSystem<double> {
 
   int get_updated_pose_models_input_port_index() const { return updated_pose_models_input_port_index_; }
 
-  // This is the color used by the directional light added to each scene.
-  const ignition::math::Color kLightColor{0.9, 0.9, 0.9};
-
-  // This is the direction of the directional light added to each scene.
-  const ignition::math::Vector3d kLightDirection{-0.5, -0.5, -1};
-
-  // Cast shadows by default.
-  bool kCastShadowsByDefault{true};
-
  private:
   // Calculates a new scene message from the geometry description and the
   // updated poses of mobile elements.
   void CalcSceneMessage(const drake::systems::Context<double>& context, ignition::msgs::Scene* scene_message) const;
+
+  // This is the color used by the directional light added to each scene.
+  static const ignition::math::Color kLightColor;
+
+  // This is the direction of the directional light added to each scene.
+  static const ignition::math::Vector3d kLightDirection;
+
+  // Cast shadows by default.
+  static const bool kCastShadowsByDefault{true};
 
   int geometry_models_input_port_index_{};
   int updated_pose_models_input_port_index_{};


### PR DESCRIPTION
Use hard-coded light parameters [copied from visualizer0](https://github.com/ToyotaResearchInstitute/delphyne-gui/blob/master/delphyne_gui/visualizer/render_widget.cc#L573-L582). The [visualizer0 render_widget](https://github.com/ToyotaResearchInstitute/delphyne-gui/blob/3caefe2b2bcaaba3d3dadb4dca12bff79a1feda2/delphyne_gui/visualizer/render_widget.cc#L388-L395) will need to be updated in order to parse this portion of the scene message.

This doesn't fix the textures, but it at least makes the shape of the vehicles more visible, so the visualizer is much more functional. I will post a screenshot.