### PR TITLE
Fixes warnings after drake migration due to a deprecated method.

### DIFF
--- a/src/backend/ign_subscriber_system.h
+++ b/src/backend/ign_subscriber_system.h
@@ -39,7 +39,7 @@ class IgnSubscriberSystem : public drake::systems::LeafSystem<double> {
                                 this->IgnSubscriberSystem::CalcIgnMessage(context, out);
                               });
     DeclareAbstractState(drake::Value<IGN_TYPE>{IGN_TYPE{}});
-    DeclareAbstractState(*drake::AbstractValue::Make<int>(0));
+    DeclareAbstractState(drake::Value<int>(0));
 
     if (!node_.Subscribe(topic_name_, &IgnSubscriberSystem<IGN_TYPE>::HandleMessage, this)) {
       ignerr << "Error subscribing to topic: " << topic_name_ << "\n Ignition Subscriber will not work" << std::endl;

--- a/src/systems/idm_controller.cc
+++ b/src/systems/idm_controller.cc
@@ -45,7 +45,7 @@ IDMController<T>::IDMController(const RoadGeometry& road, ScanStrategy path_or_b
   // a caching sceme once #4364 lands, preventing the need to use abstract
   // states and periodic sampling time.
   if (road_position_strategy == RoadPositionStrategy::kCache) {
-    this->DeclareAbstractState(*drake::AbstractValue::Make<RoadPosition>(RoadPosition()));
+    this->DeclareAbstractState(drake::Value<RoadPosition>{});
     this->DeclarePeriodicUnrestrictedUpdate(period_sec, 0);
   }
 }

--- a/src/systems/mobil_planner.cc
+++ b/src/systems/mobil_planner.cc
@@ -51,7 +51,7 @@ MobilPlanner<T>::MobilPlanner(const RoadGeometry& road, bool initial_with_s,
   // a caching sceme once #4364 lands, preventing the need to use abstract
   // states and periodic sampling time.
   if (road_position_strategy == RoadPositionStrategy::kCache) {
-    this->DeclareAbstractState(*drake::AbstractValue::Make<RoadPosition>(RoadPosition()));
+    this->DeclareAbstractState(drake::Value<RoadPosition>{});
     this->DeclarePeriodicUnrestrictedUpdate(period_sec, 0);
   }
 }

--- a/src/systems/rail_follower.cc
+++ b/src/systems/rail_follower.cc
@@ -99,8 +99,7 @@ RailFollower<T>::RailFollower(const LaneDirection& initial_lane_direction,
   pose_output_port_index_ = this->DeclareVectorOutputPort(&RailFollower::CalcPose).get_index();
   velocity_output_port_index_ =
       this->DeclareVectorOutputPort(&RailFollower::CalcVelocity, {this->xc_ticket()}).get_index();
-  lane_direction_context_index_ =
-      this->DeclareAbstractState(*drake::AbstractValue::Make<LaneDirection>(initial_lane_direction));
+  lane_direction_context_index_ = this->DeclareAbstractState(drake::Value<LaneDirection>{initial_lane_direction});
   rail_follower_params_context_index_ = this->DeclareNumericParameter(initial_context_parameters);
   this->DeclareContinuousState(initial_context_state);
 }

--- a/src/systems/vector_source.h
+++ b/src/systems/vector_source.h
@@ -39,7 +39,7 @@ class VectorSource final : public drake::systems::LeafSystem<T> {
   explicit VectorSource(T defaultval) {
     output_port_index_ =
         this->DeclareVectorOutputPort(drake::systems::BasicVector<T>(1), &VectorSource::CalcOutputValue).get_index();
-    this->DeclareAbstractState(*drake::AbstractValue::Make<T>(T{defaultval}));
+    this->DeclareAbstractState(drake::Value<T>{defaultval});
     val_ = defaultval;
   }
 


### PR DESCRIPTION
Related to https://github.com/ToyotaResearchInstitute/drake_vendor/issues/33#issuecomment-801662672

After `drake` migration to v0.27.0. some warnings occurred because of the deprecation (as of april) of this method:
```cpp
  /** Declares an abstract state.
  @param abstract_state The abstract state model value.  The internal model
  value will contain a copy of `value` (not retain a pointer to `value`).
  @return index of the declared abstract state. */
  DRAKE_DEPRECATED("2021-04-01",
      "Pass the abstract_state by value, not by-unique-ptr")
  AbstractStateIndex DeclareAbstractState(
      std::unique_ptr<AbstractValue> abstract_state);
```



