### PR TITLE
Renames ament_cmake_doxygen's mainline branch.

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -2,7 +2,7 @@ repositories:
   ament_cmake_doxygen:
     type: git
     url: https://github.com/ToyotaResearchInstitute/ament_cmake_doxygen
-    version: master
+    version: main
   pybind11:
     type: git
     url: https://github.com/RobotLocomotion/pybind11.git


### PR DESCRIPTION
Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/191