### PR TITLE
Removes extra std::move.

### DIFF
--- a/include/delphyne/mi6/agent_diagram_builder.h
+++ b/include/delphyne/mi6/agent_diagram_builder.h
@@ -128,7 +128,7 @@ class AgentDiagramBuilder : public drake::systems::DiagramBuilder<T> {
     diagram->set_name(name_);
     diagram->set_input_names(inputs_mapping_);
     diagram->set_output_names(outputs_mapping_);
-    return std::move(diagram);
+    return diagram;
   }
 
  private:


### PR DESCRIPTION
Flagged when compiling delphyne, this std::move is unnecessary.