### PR TITLE
Remove pydrake dependencies from python bindings.

### DIFF
--- a/python/delphyne/agents.cc
+++ b/python/delphyne/agents.cc
@@ -49,8 +49,6 @@ namespace {
 *****************************************************************************/
 
 PYBIND11_MODULE(agents, m) {
-  py::module::import("pydrake.common.eigen_geometry");
-  py::module::import("pydrake.systems.framework");
   py::module::import("maliput.api");
 
   py::class_<Agent>(m, "Agent")

--- a/python/delphyne/simulation.cc
+++ b/python/delphyne/simulation.cc
@@ -43,7 +43,6 @@ namespace {
 *****************************************************************************/
 
 PYBIND11_MODULE(simulation, m) {
-  py::module::import("pydrake.systems.framework");
   py::module::import("maliput.api");
 
   py::class_<InteractiveSimulationStats>(m, "InteractiveSimulationStats")


### PR DESCRIPTION
Just what the title says.

It enables tests in focal+foxy environment to run successfully.

Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196