### PR TITLE
Removes unexported multilane header file.

### DIFF
--- a/test/regression/cpp/traffic_pose_selector_test.cc
+++ b/test/regression/cpp/traffic_pose_selector_test.cc
@@ -7,7 +7,6 @@
 #include <maliput/api/lane.h>
 #include <maliput/api/road_geometry.h>
 #include <maliput_multilane/builder.h>
-#include <maliput_multilane/road_geometry.h>
 
 #include "delphyne/roads/road_builder.h"
 


### PR DESCRIPTION
Pairs with ToyotaResearchInstitute/maliput_multilane#68