### PR TITLE
Brings in eigen_compare_matrices.h

### DIFF
--- a/test/regression/cpp/CMakeLists.txt
+++ b/test/regression/cpp/CMakeLists.txt
@@ -27,7 +27,6 @@ target_link_libraries(test_utilities
   ignition-common3::ignition-common3
   ignition-msgs5::ignition-msgs5
   ignition-transport8::ignition-transport8
-  maliput_multilane::test_utilities
 )
 
 ##############################################################################

--- a/test/regression/cpp/bicycle_car_test.cc
+++ b/test/regression/cpp/bicycle_car_test.cc
@@ -7,8 +7,8 @@
 #include <utility>
 
 #include <gtest/gtest.h>
-#include <maliput_multilane_test_utilities/eigen_matrix_compare.h>
 
+#include "test_utilities/eigen_matrix_compare.h"
 #include "test_utilities/scalar_conversion.h"
 
 namespace delphyne {

--- a/test/regression/cpp/box_car_vis_test.cc
+++ b/test/regression/cpp/box_car_vis_test.cc
@@ -5,7 +5,8 @@
 #include <drake/systems/rendering/pose_bundle.h>
 #include <drake/systems/rendering/pose_vector.h>
 #include <gtest/gtest.h>
-#include <maliput_multilane_test_utilities/eigen_matrix_compare.h>
+
+#include "test_utilities/eigen_matrix_compare.h"
 
 using std::vector;
 

--- a/test/regression/cpp/calc_ongoing_road_position_test.cc
+++ b/test/regression/cpp/calc_ongoing_road_position_test.cc
@@ -4,9 +4,9 @@
 #include <gtest/gtest.h>
 #include <maliput/api/road_geometry.h>
 #include <maliput_multilane/multilane_onramp_merge.h>
-#include <maliput_multilane_test_utilities/eigen_matrix_compare.h>
 
 #include "delphyne/roads/road_builder.h"
+#include "test_utilities/eigen_matrix_compare.h"
 
 namespace delphyne {
 

--- a/test/regression/cpp/car_vis_applicator_test.cc
+++ b/test/regression/cpp/car_vis_applicator_test.cc
@@ -12,8 +12,8 @@
 #include <drake/systems/rendering/pose_bundle.h>
 #include <drake/systems/rendering/pose_vector.h>
 #include <gtest/gtest.h>
-#include <maliput_multilane_test_utilities/eigen_matrix_compare.h>
 
+#include "test_utilities/eigen_matrix_compare.h"
 #include "visualization/box_car_vis.h"
 #include "visualization/car_vis.h"
 

--- a/test/regression/cpp/idm_controller_test.cc
+++ b/test/regression/cpp/idm_controller_test.cc
@@ -5,9 +5,9 @@
 #include <drake/multibody/math/spatial_velocity.h>
 #include <gtest/gtest.h>
 #include <maliput/api/road_geometry.h>
-#include <maliput_multilane_test_utilities/eigen_matrix_compare.h>
 
 #include "delphyne/roads/road_builder.h"
+#include "test_utilities/eigen_matrix_compare.h"
 #include "test_utilities/scalar_conversion.h"
 
 namespace delphyne {

--- a/test/regression/cpp/mobil_planner_test.cc
+++ b/test/regression/cpp/mobil_planner_test.cc
@@ -6,9 +6,9 @@
 #include <drake/math/rigid_transform.h>
 #include <gtest/gtest.h>
 #include <maliput/api/road_geometry.h>
-#include <maliput_multilane_test_utilities/eigen_matrix_compare.h>
 
 #include "delphyne/roads/road_builder.h"
+#include "test_utilities/eigen_matrix_compare.h"
 
 namespace delphyne {
 namespace test_p {

--- a/test/regression/cpp/prius_vis_test.cc
+++ b/test/regression/cpp/prius_vis_test.cc
@@ -9,7 +9,8 @@
 #include <drake/systems/rendering/frame_velocity.h>
 #include <drake/systems/rendering/pose_bundle.h>
 #include <gtest/gtest.h>
-#include <maliput_multilane_test_utilities/eigen_matrix_compare.h>
+
+#include "test_utilities/eigen_matrix_compare.h"
 
 namespace delphyne {
 

--- a/test/regression/cpp/road_path_test.cc
+++ b/test/regression/cpp/road_path_test.cc
@@ -9,7 +9,8 @@
 #include <maliput/api/road_geometry.h>
 #include <maliput_dragway/road_geometry.h>
 #include <maliput_multilane/builder.h>
-#include <maliput_multilane_test_utilities/eigen_matrix_compare.h>
+
+#include "test_utilities/eigen_matrix_compare.h"
 
 namespace delphyne {
 namespace {

--- a/test/regression/cpp/simple_car_test.cc
+++ b/test/regression/cpp/simple_car_test.cc
@@ -6,9 +6,9 @@
 #include <drake/common/symbolic.h>
 #include <drake/systems/framework/system_constraint.h>
 #include <gtest/gtest.h>
-#include <maliput_multilane_test_utilities/eigen_matrix_compare.h>
 
 #include "gen/simple_car_state.h"
+#include "test_utilities/eigen_matrix_compare.h"
 #include "test_utilities/scalar_conversion.h"
 
 namespace delphyne {

--- a/test/regression/cpp/test_utilities/autodiff_test_utilities.h
+++ b/test/regression/cpp/test_utilities/autodiff_test_utilities.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <drake/common/autodiff.h>
-#include <maliput_multilane_test_utilities/eigen_matrix_compare.h>
+
+#include "test_utilities/eigen_matrix_compare.h"
 
 namespace delphyne {
 

--- a/test/regression/cpp/test_utilities/eigen_matrix_compare.h
+++ b/test/regression/cpp/test_utilities/eigen_matrix_compare.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include <Eigen/Dense>
+#include <gtest/gtest.h>
+#include <maliput/common/logger.h>
+
+enum class MatrixCompareType { absolute, relative };
+
+/**
+ * Assert that two matrices @p m1 and @p m2 are equal down to a certain @p tolerance.
+ *
+ * @param m1 The first matrix to compare.
+ * @param m2 The second matrix to compare.
+ * @param tolerance The tolerance for determining equivalence.
+ * @param compare_type Whether the tolerance is absolute or relative.
+ * @return \::testing\::AssertionSuccess if the two matrices are equal based on the specified
+ * tolerance, \::testing\::AssertionFailure otherwise.
+ */
+template <typename DerivedA, typename DerivedB>
+::testing::AssertionResult CompareMatrices(const Eigen::MatrixBase<DerivedA>& m1, const Eigen::MatrixBase<DerivedB>& m2,
+                                           double tolerance = 0.0,
+                                           MatrixCompareType compare_type = MatrixCompareType::absolute) {
+  if (m1.rows() != m2.rows() || m1.cols() != m2.cols()) {
+    return ::testing::AssertionFailure() << "Matrix size mismatch: (" << m1.rows() << " x " << m1.cols() << " vs. "
+                                         << m2.rows() << " x " << m2.cols() << ")";
+  }
+
+  for (int ii = 0; ii < m1.rows(); ii++) {
+    for (int jj = 0; jj < m1.cols(); jj++) {
+      // First handle the corner cases of positive infinity, negative infinity,
+      // and NaN
+      const auto both_positive_infinity = m1(ii, jj) == std::numeric_limits<double>::infinity() &&
+                                          m2(ii, jj) == std::numeric_limits<double>::infinity();
+
+      const auto both_negative_infinity = m1(ii, jj) == -std::numeric_limits<double>::infinity() &&
+                                          m2(ii, jj) == -std::numeric_limits<double>::infinity();
+
+      using std::isnan;
+      const auto both_nan = isnan(m1(ii, jj)) && isnan(m2(ii, jj));
+
+      if (both_positive_infinity || both_negative_infinity || both_nan) continue;
+
+      // Check for case where one value is NaN and the other is not
+      if ((isnan(m1(ii, jj)) && !isnan(m2(ii, jj))) || (!isnan(m1(ii, jj)) && isnan(m2(ii, jj)))) {
+        return ::testing::AssertionFailure() << "NaN mismatch at (" << ii << ", " << jj << "):\nm1 =\n"
+                                             << m1 << "\nm2 =\n"
+                                             << m2;
+      }
+
+      // Determine whether the difference between the two matrices is less than
+      // the tolerance.
+      using std::abs;
+      const auto delta = abs(m1(ii, jj) - m2(ii, jj));
+
+      if (compare_type == MatrixCompareType::absolute) {
+        // Perform comparison using absolute tolerance.
+
+        if (delta > tolerance) {
+          return ::testing::AssertionFailure()
+                 << "Values at (" << ii << ", " << jj << ") exceed tolerance: " << m1(ii, jj) << " vs. " << m2(ii, jj)
+                 << ", diff = " << delta << ", tolerance = " << tolerance << "\nm1 =\n"
+                 << m1 << "\nm2 =\n"
+                 << m2 << "\ndelta=\n"
+                 << (m1 - m2);
+        }
+      } else {
+        // Perform comparison using relative tolerance, see:
+        // http://realtimecollisiondetection.net/blog/?p=89
+        using std::max;
+        const auto max_value = max(abs(m1(ii, jj)), abs(m2(ii, jj)));
+        const auto relative_tolerance = tolerance * max(decltype(max_value){1}, max_value);
+
+        if (delta > relative_tolerance) {
+          return ::testing::AssertionFailure()
+                 << "Values at (" << ii << ", " << jj << ") exceed tolerance: " << m1(ii, jj) << " vs. " << m2(ii, jj)
+                 << ", diff = " << delta << ", tolerance = " << tolerance
+                 << ", relative tolerance = " << relative_tolerance << "\nm1 =\n"
+                 << m1 << "\nm2 =\n"
+                 << m2 << "\ndelta=\n"
+                 << (m1 - m2);
+        }
+      }
+    }
+  }
+
+  return ::testing::AssertionSuccess() << "m1 =\n" << m1 << "\nis approximately equal to m2 =\n" << m2;
+}

--- a/test/regression/cpp/trajectory_test.cc
+++ b/test/regression/cpp/trajectory_test.cc
@@ -7,7 +7,8 @@
 #include <Eigen/Geometry>
 #include <drake/math/roll_pitch_yaw.h>
 #include <gtest/gtest.h>
-#include <maliput_multilane_test_utilities/eigen_matrix_compare.h>
+
+#include "test_utilities/eigen_matrix_compare.h"
 
 namespace delphyne {
 namespace {

--- a/test/regression/cpp/unicycle_car_test.cc
+++ b/test/regression/cpp/unicycle_car_test.cc
@@ -4,9 +4,9 @@
 #include <memory>
 
 #include <gtest/gtest.h>
-#include <maliput_multilane_test_utilities/eigen_matrix_compare.h>
 
 #include "gen/simple_car_state.h"
+#include "test_utilities/eigen_matrix_compare.h"
 
 namespace delphyne {
 


### PR DESCRIPTION
Part of  ToyotaResearchInstitute/maliput_infrastructure#232

Transfers the maliput_multilane header file here. See https://github.com/ToyotaResearchInstitute/maliput_multilane/pull/71 counterpart.

