### PR TITLE
Fixes bug in LaneLocationProvider.

### DIFF
--- a/python/delphyne/blackboard/providers.py
+++ b/python/delphyne/blackboard/providers.py
@@ -43,8 +43,10 @@ class LaneLocationProvider():
         for lane in lanes:
             lane_id = lane.id().string()
             step_size = self.distance_between_agents
-            step_count = int(lane.length() / step_size)
-            step_count = 1 if step_count == 0 else step_count
+            # When `lane.length()`` is less than `step_size` a lane position at the
+            # start of the lane is expected to be created so as to to guarantee at
+            # least one lane position per lane.
+            step_count = max(int(lane.length() / step_size), 1)
             lane_locations[lane_id] = [
                 maliput.LanePosition(
                     s=i * step_size, r=0., h=0.


### PR DESCRIPTION
resolves https://github.com/ToyotaResearchInstitute/delphyne_demos/issues/30

When the `step_count` is zero because the `step_size` is less than the length of the `lane` then it generates a `lane_position` at the beginning of the lane, in contrast with the old behavior where none lane position was generated in that case, occasioning an error downstream.


### Why did we miss it in bionic?
`delphyne_city` demo was working on `bionic`(python 3.6.9) because the random lanes that were being selected were always the same (because the seed was the same) and it happened that, luckily, none lane without available `lane_position` was selected. When running in `focal`(python 3.8.10), the selected random lanes changed and now some lanes, which no `lane_position` were generated, were now selected.