### PR TITLE
Fixes malidrive loader call.

### DIFF
--- a/src/roads/road_builder.cc
+++ b/src/roads/road_builder.cc
@@ -79,7 +79,7 @@ std::unique_ptr<maliput::api::RoadNetwork> CreateMalidriveRoadNetworkFromXodr(
     road_network_configuration.emplace("traffic_light_book", traffic_light_book_path);
   }
   if (!phase_ring_path.empty()) {
-    road_network_configuration.emplace("phase_ring_path", phase_ring_path);
+    road_network_configuration.emplace("phase_ring_book", phase_ring_path);
   }
 
   return malidrive::loader::Load<malidrive::builder::RoadNetworkBuilder>(road_network_configuration);


### PR DESCRIPTION
The parameter related to the phase ring book for the malidrive builder wasn't correct.

I created https://github.com/ToyotaResearchInstitute/maliput_malidrive/issues/179 to add a verification step.