### PR TITLE
Fixes lambda's capture of non automatic storage variables.

### DIFF
--- a/src/backend/geometry_utilities.cc
+++ b/src/backend/geometry_utilities.cc
@@ -33,7 +33,7 @@ void CreateAndRegisterBulb(const std::string& unique_bulb_id, const maliput::mat
   static const Eigen::Vector4d kYellow(1.0, 1.0, 0.0, 1.0);
   static const Eigen::Vector4d kRed(1.0, 0.0, 0.0, 1.0);
 
-  auto get_color = [&kRed, &kYellow, &kGreen](const maliput::api::rules::BulbColor& bulb_color) {
+  auto get_color = [](const maliput::api::rules::BulbColor& bulb_color) {
     switch (bulb_color) {
       case maliput::api::rules::BulbColor::kRed:
         return kRed;


### PR DESCRIPTION
Lambda function was capturing by reference static storage variables, leading to an error (when clang compiling) and potential undefined behavior.