### PR TITLE
Uses ament_add_pytest_test instead.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,15 +99,6 @@ jobs:
         colcon build --packages-up-to ${PACKAGE_NAME} \
           --event-handlers=console_direct+ \
           --cmake-args -DBUILD_TESTING=OFF -DBUILD_DOCS=OFF;
-    # Build maliput libraries.
-    - name: colcon build maliput backends
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-      run: |
-        . /opt/ros/${ROS_DISTRO}/setup.bash;
-        colcon build --packages-up-to maliput_dragway maliput_multilane maliput_malidrive \
-          --event-handlers=console_direct+ \
-          --cmake-args -DBUILD_TESTING=OFF -DBUILD_DOCS=OFF;
     # Build tests for current package.
     - name: colcon build tests
       shell: bash

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -117,15 +117,6 @@ jobs:
           --event-handlers=console_direct+ \
           --cmake-args ${COMPILER_FLAG} \
             -DBUILD_TESTING=OFF
-    - name: colcon build maliput backends
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-      run: |
-        . /opt/ros/${ROS_DISTRO}/setup.bash;
-        colcon build --packages-up-to maliput_dragway maliput_multilane maliput_malidrive \
-          --event-handlers=console_direct+ \
-          --cmake-args ${COMPILER_FLAG} \
-            -DBUILD_TESTING=OFF
     - name: colcon build tests
       shell: bash
       working-directory: ${{ env.ROS_WS }}

--- a/package.xml
+++ b/package.xml
@@ -31,6 +31,10 @@
   <exec_depend>ament_cmake</exec_depend>
   <exec_depend>py_trees</exec_depend>
 
+  <exec_depend>maliput_dragway</exec_depend>
+  <exec_depend>maliput_malidrive</exec_depend>
+  <exec_depend>maliput_multilane</exec_depend>
+
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_flake8</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,7 @@
 ##############################################################################
 
 find_package(ament_cmake_gtest REQUIRED)
+find_package(ament_cmake_pytest REQUIRED)
 
 # Find the Python interpreter for running the check_test_ran.py script
 find_package(PythonInterp QUIET)
@@ -67,7 +68,10 @@ macro(delphyne_build_python_tests)
       string(REGEX REPLACE ".py" "" PY_TEST ${PYTHON_TEST_file})
       set(PY_TEST ${TEST_TYPE}_${PY_TEST})
 
-      add_test(NAME ${PY_TEST} COMMAND ${PYTHON_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR})
+      ament_add_pytest_test(${PY_TEST}
+        ${PYTHON_TEST_file}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      )
     endforeach()
   endif()
 endmacro()


### PR DESCRIPTION
### Summary
- Fixes CI by using ament_add_pytest_test instead of custom add_test command.
- Adds missing dependency in the pacakge.xml 