### PR TITLE
Adds reference_internal label to a binding.

### DIFF
--- a/python/delphyne/roads.cc
+++ b/python/delphyne/roads.cc
@@ -107,7 +107,9 @@ PYBIND11_MODULE(roads, m) {
       .def_readwrite("branch_point_height", &ObjFeatures::branch_point_height);
 
   py::class_<delphyne::roads::RoadNetworkWrapper>(m, "RoadNetworkWrapper")
-      .def("get", [](const delphyne::roads::RoadNetworkWrapper* self) { return self->operator->(); });
+      .def(
+          "get", [](const delphyne::roads::RoadNetworkWrapper* self) { return self->operator->(); },
+          py::return_value_policy::reference_internal);
 }
 
 /*****************************************************************************


### PR DESCRIPTION
This was missing and it was causing a seg fault when exiting the demos.
See https://github.com/maliput/delphyne_demos/runs/7198049503?check_suite_focus=true
Test failing at PR: https://github.com/maliput/delphyne_demos/pull/43

Signed-off-by: Franco Cipollone <franco.c@ekumenlabs.com>