### PR TITLE
Adds maliput_osm road builder.

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -27,6 +27,14 @@ repositories:
     type: git
     url: https://github.com/maliput/maliput_multilane
     version: main
+  maliput_sparse:
+    type: git
+    url: https://github.com/maliput/maliput_sparse
+    version: main
+  maliput_osm:
+    type: git
+    url: https://github.com/maliput/maliput_osm
+    version: main
   maliput_py:
     type: git
     url: https://github.com/maliput/maliput_py

--- a/include/delphyne/roads/road_builder.h
+++ b/include/delphyne/roads/road_builder.h
@@ -137,6 +137,27 @@ std::unique_ptr<maliput::api::RoadNetwork> CreateMalidriveRoadNetworkFromXodr(
 /// @brief Creates a multilane on-ramp.
 std::unique_ptr<maliput::api::RoadNetwork> CreateOnRamp();
 
+/// @brief Creates a maliput_osm based RoadNetwork from osm source.
+///
+/// @param[in] name A name for the road geometry to be created.
+/// @param[in] file_path A string pointing to the OSM file to be loaded.
+/// @param[in] origin A 2D-vector representing the origin(lat-long) of the OSM map.
+/// @param[in] rule_registry_file_path A string pointing to the RuleRegistry file to be loaded.
+/// @param[in] road_rulebook_file_path A string pointing to the Rulebook file to be loaded.
+/// @param[in] traffic_light_book_path A string pointing to the TrafficLightBook file to be loaded.
+/// @param[in] phase_ring_path A string pointing to the PhaseRingBook file to be loaded.
+/// @param[in] intersection_book_path A string pointing to the IntersectionBook file to be loaded.
+/// @param[in] linear_tolerance The linear RoadGeometry tolerance. Default value is 1e-3m.
+/// @param[in] angular_tolerance The angular RoadGeometry tolerance. Default value is 1e-3rad.
+/// @return A maliput::api::RoadNetwork.
+std::unique_ptr<maliput::api::RoadNetwork> CreateMaliputOSMRoadNetwork(
+    const std::string& name, const std::string& file_path, const std::string& origin = std::string(),
+    const std::string& rule_registry_file_path = std::string(),
+    const std::string& road_rulebook_file_path = std::string(),
+    const std::string& traffic_light_book_path = std::string(), const std::string& phase_ring_path = std::string(),
+    const std::string& intersection_book_path = std::string(), double linear_tolerance = 1e-3,
+    double angular_tolerance = 1e-3);
+
 /*****************************************************************************
 ** Trailers
 *****************************************************************************/

--- a/package.xml
+++ b/package.xml
@@ -34,6 +34,7 @@
   <exec_depend>maliput_dragway</exec_depend>
   <exec_depend>maliput_malidrive</exec_depend>
   <exec_depend>maliput_multilane</exec_depend>
+  <exec_depend>maliput_osm</exec_depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_flake8</test_depend>

--- a/python/delphyne/behaviours/roads.py
+++ b/python/delphyne/behaviours/roads.py
@@ -155,6 +155,46 @@ class Malidrive(Road):
                     angular_tolerance=self.angular_tolerance), self.features)
             self.road_geometry = self.road_network.road_geometry()
 
+class MaliputOSM(Road):
+    """
+    A maliput osm road.
+    """
+
+    def __init__(self, name=py_trees.common.Name.AUTO_GENERATED,
+                 file_path="", origin="", rule_registry_file_path="", road_rulebook_file_path="",
+                 traffic_light_book_path="", phase_ring_path="", intersection_book_path="",
+                 linear_tolerance=1e-3, angular_tolerance=1e-3,
+                 features=delphyne.roads.ObjFeatures()):
+        super().__init__(name)
+        self.road_network = None
+        self.name = name
+        self.file_path = file_path
+        self.origin = origin
+        self.rule_registry_file_path = rule_registry_file_path
+        self.road_rulebook_file_path = road_rulebook_file_path
+        self.traffic_light_book_path = traffic_light_book_path
+        self.phase_ring_path = phase_ring_path
+        self.intersection_book_path = intersection_book_path
+        self.linear_tolerance = linear_tolerance
+        self.angular_tolerance = angular_tolerance
+        self.features = features
+
+    def setup(self, *, builder):
+        if self.road_network is None:
+            # Setup a road network only the first time.
+            self.road_network = builder.set_road_network(
+                delphyne.roads.create_maliput_osm_road_network(
+                    name=self.name,
+                    file_path=self.file_path,
+                    origin = self.origin,
+                    rule_registry_file_path=self.rule_registry_file_path,
+                    road_rulebook_file_path=self.road_rulebook_file_path,
+                    traffic_light_book_path=self.traffic_light_book_path,
+                    phase_ring_path=self.phase_ring_path,
+                    intersection_book_path=self.intersection_book_path,
+                    linear_tolerance=self.linear_tolerance,
+                    angular_tolerance=self.angular_tolerance), self.features)
+            self.road_geometry = self.road_network.road_geometry()
 
 class OnRamp(Road):
     """

--- a/python/delphyne/behaviours/roads.py
+++ b/python/delphyne/behaviours/roads.py
@@ -155,6 +155,7 @@ class Malidrive(Road):
                     angular_tolerance=self.angular_tolerance), self.features)
             self.road_geometry = self.road_network.road_geometry()
 
+
 class MaliputOSM(Road):
     """
     A maliput osm road.
@@ -186,7 +187,7 @@ class MaliputOSM(Road):
                 delphyne.roads.create_maliput_osm_road_network(
                     name=self.name,
                     file_path=self.file_path,
-                    origin = self.origin,
+                    origin=self.origin,
                     rule_registry_file_path=self.rule_registry_file_path,
                     road_rulebook_file_path=self.road_rulebook_file_path,
                     traffic_light_book_path=self.traffic_light_book_path,
@@ -195,6 +196,7 @@ class MaliputOSM(Road):
                     linear_tolerance=self.linear_tolerance,
                     angular_tolerance=self.angular_tolerance), self.features)
             self.road_geometry = self.road_network.road_geometry()
+
 
 class OnRamp(Road):
     """

--- a/python/delphyne/roads.cc
+++ b/python/delphyne/roads.cc
@@ -87,6 +87,12 @@ PYBIND11_MODULE(roads, m) {
         py::arg("phase_ring_path"), py::arg("intersection_book_path"), py::arg("linear_tolerance") = 1e-3,
         py::arg("angular_tolerance") = 1e-3);
 
+  m.def("create_maliput_osm_road_network", &delphyne::roads::CreateMaliputOSMRoadNetwork,
+        "Load an full RoadNetwork based on maliput_osm backend", py::arg("name"), py::arg("file_path"),
+        py::arg("origin"), py::arg("rule_registry_file_path"), py::arg("road_rulebook_file_path"),
+        py::arg("traffic_light_book_path"), py::arg("phase_ring_path"), py::arg("intersection_book_path"),
+        py::arg("linear_tolerance") = 1e-3, py::arg("angular_tolerance") = 1e-3);
+
   py::class_<ObjFeatures>(m, "ObjFeatures")
       .def(py::init<>())
       .def_readwrite("max_grid_unit", &ObjFeatures::max_grid_unit)

--- a/src/roads/road_builder.cc
+++ b/src/roads/road_builder.cc
@@ -139,6 +139,42 @@ std::unique_ptr<maliput::api::RoadNetwork> CreateMalidriveRoadNetworkFromXodr(
   return maliput::plugin::CreateRoadNetwork("maliput_malidrive", road_network_configuration);
 }
 
+std::unique_ptr<maliput::api::RoadNetwork> CreateMaliputOSMRoadNetwork(
+    const std::string& name, const std::string& file_path, const std::string& origin,
+    const std::string& rule_registry_file_path, const std::string& road_rulebook_file_path,
+    const std::string& traffic_light_book_path, const std::string& phase_ring_path,
+    const std::string& intersection_book_path, double linear_tolerance, double angular_tolerance) {
+  static constexpr double kScaleLength{1.};
+  std::map<std::string, std::string> config{
+      {"road_geometry_id", name},
+      {"osm_file", file_path},
+      {"linear_tolerance", std::to_string(linear_tolerance)},
+      {"angular_tolerance", std::to_string(angular_tolerance)},
+      {"scale_length", std::to_string(kScaleLength)},
+  };
+
+  if (!origin.empty()) {
+    config.emplace("origin", origin);
+  }
+  if (!rule_registry_file_path.empty()) {
+    config.emplace("rule_registry", rule_registry_file_path);
+  }
+  if (!road_rulebook_file_path.empty()) {
+    config.emplace("road_rule_book", road_rulebook_file_path);
+  }
+  if (!traffic_light_book_path.empty()) {
+    config.emplace("traffic_light_book", traffic_light_book_path);
+  }
+  if (!phase_ring_path.empty()) {
+    config.emplace("phase_ring_book", phase_ring_path);
+  }
+  if (!phase_ring_path.empty()) {
+    config.emplace("intersection_book", intersection_book_path);
+  }
+
+  return maliput::plugin::CreateRoadNetwork("maliput_osm", config);
+}
+
 /*****************************************************************************
  ** Trailers
  *****************************************************************************/


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput_osm/issues/9

Relies on https://github.com/maliput/maliput_osm/pull/15

## Summary
Add support for creating a `maliput_osm`-based `maliput::api::RoadNetwork`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

